### PR TITLE
feat(api): implementar HATEOAS y gestión de rubros/artículos

### DIFF
--- a/src/main/java/eterea/core/service/configuration/WebConfig.java
+++ b/src/main/java/eterea/core/service/configuration/WebConfig.java
@@ -7,8 +7,11 @@ import org.springframework.http.HttpMethod;
 import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
 
 @Configuration
+@EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
 public class WebConfig {
 
     @Bean
@@ -36,6 +39,15 @@ public class WebConfig {
                                 HttpHeaders.AUTHORIZATION
                         );
             }
+        };
+    }
+
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer pageableCustomizer() {
+        return pageableResolver -> {
+            pageableResolver.setMaxPageSize(100);
+            pageableResolver.setPageParameterName("page");
+            pageableResolver.setSizeParameterName("size");
         };
     }
 }

--- a/src/main/java/eterea/core/service/controller/ArticuloListaPrecioController.java
+++ b/src/main/java/eterea/core/service/controller/ArticuloListaPrecioController.java
@@ -1,12 +1,21 @@
 package eterea.core.service.controller;
 
+import eterea.core.service.kotlin.exception.ArticuloListaPrecioException;
 import eterea.core.service.kotlin.model.ArticuloListaPrecio;
 import eterea.core.service.service.ArticuloListaPrecioService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @CrossOrigin(origins = "*")
 @RestController
@@ -20,21 +29,85 @@ public class ArticuloListaPrecioController {
     }
 
     @GetMapping("/page")
-    public ResponseEntity<Page<ArticuloListaPrecio>> findAllPublicadosPaginated(
+    public ResponseEntity<CollectionModel<EntityModel<ArticuloListaPrecio>>> findAllPublicadosPaginated(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "30") int size) {
+            
         Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(service.findAllPublicadosPaginated(pageable));
+        Page<ArticuloListaPrecio> pageResult = service.findAllPublicadosPaginated(pageable);
+        
+        List<EntityModel<ArticuloListaPrecio>> articulos = pageResult.getContent().stream()
+            .map(articulo -> EntityModel.of(articulo,
+                WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                    .findByArticuloId(articulo.getArticuloId())).withSelfRel(),
+                WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                    .findAllPublicadosPaginated(page, size)).withRel("articulos")))
+            .collect(Collectors.toList());
+
+        CollectionModel<EntityModel<ArticuloListaPrecio>> result = CollectionModel.of(articulos);
+        
+        if (pageResult.hasNext()) {
+            result.add(WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                .findAllPublicadosPaginated(page + 1, size)).withRel("next"));
+        }
+        if (pageResult.hasPrevious()) {
+            result.add(WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                .findAllPublicadosPaginated(page - 1, size)).withRel("prev"));
+        }
+
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{articuloId}")
     public ResponseEntity<ArticuloListaPrecio> findByArticuloId(@PathVariable String articuloId) {
-        return ResponseEntity.ok(service.findByArticuloId(articuloId));
+        try {
+            return ResponseEntity.ok(service.findByArticuloId(articuloId));
+        } catch (ArticuloListaPrecioException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
     }
 
     @GetMapping("/publicar/{articuloId}/{publicar}")
     public ResponseEntity<ArticuloListaPrecio> publicar(@PathVariable String articuloId, @PathVariable Byte publicar) {
         return ResponseEntity.ok(service.publicar(articuloId, publicar));
+    }
+
+    @GetMapping("/rubro/{rubroId}/page")
+    public ResponseEntity<CollectionModel<EntityModel<ArticuloListaPrecio>>> findAllByRubroIdPaginated(
+            @PathVariable Integer rubroId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "30") int size) {
+            
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ArticuloListaPrecio> pageResult = service.findAllByRubroIdPaginated(rubroId, pageable);
+        
+        List<EntityModel<ArticuloListaPrecio>> articulos = pageResult.getContent().stream()
+            .map(articulo -> EntityModel.of(articulo,
+                WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                    .findByArticuloId(articulo.getArticuloId())).withSelfRel(),
+                WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                    .findAllByRubroIdPaginated(rubroId, page, size)).withRel("articulos"),
+                WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(RubroListaPrecioController.class)
+                    .findAll()).withRel("rubros")))
+            .collect(Collectors.toList());
+
+        CollectionModel<EntityModel<ArticuloListaPrecio>> result = CollectionModel.of(articulos);
+        
+        if (pageResult.hasNext()) {
+            result.add(WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                .findAllByRubroIdPaginated(rubroId, page + 1, size)).withRel("next"));
+        }
+        if (pageResult.hasPrevious()) {
+            result.add(WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(ArticuloListaPrecioController.class)
+                .findAllByRubroIdPaginated(rubroId, page - 1, size)).withRel("prev"));
+        }
+
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<ArticuloListaPrecio> addOrUpdate(@RequestBody ArticuloListaPrecio articuloListaPrecio) {
+        return ResponseEntity.ok(service.addOrUpdate(articuloListaPrecio));
     }
 
 }

--- a/src/main/java/eterea/core/service/controller/RubroListaPrecioController.java
+++ b/src/main/java/eterea/core/service/controller/RubroListaPrecioController.java
@@ -1,0 +1,58 @@
+package eterea.core.service.controller;
+
+import eterea.core.service.kotlin.exception.RubroListaPrecioException;
+import eterea.core.service.kotlin.model.RubroListaPrecio;
+import eterea.core.service.service.RubroListaPrecioService;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@RestController
+@RequestMapping({"/api/core/rubroListaPrecio", "/rubroListaPrecio"})
+public class RubroListaPrecioController {
+
+    private final RubroListaPrecioService service;
+
+    public RubroListaPrecioController(RubroListaPrecioService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<CollectionModel<EntityModel<RubroListaPrecio>>> findAll() {
+        List<EntityModel<RubroListaPrecio>> rubros = service.findAllByPublicar().stream()
+            .map(rubro -> EntityModel.of(rubro,
+                linkTo(methodOn(RubroListaPrecioController.class).findAll()).withRel("rubros"),
+                linkTo(methodOn(ArticuloListaPrecioController.class)
+                    .findAllPublicadosPaginated(0, 30)).withRel("articulos")))
+            .collect(Collectors.toList());
+
+        return ResponseEntity.ok(
+            CollectionModel.of(rubros,
+                linkTo(methodOn(RubroListaPrecioController.class).findAll()).withSelfRel())
+        );
+    }
+
+    @GetMapping("/{rubroId}")
+    public ResponseEntity<RubroListaPrecio> findByRubroId(@PathVariable Long rubroId) {
+        try {
+            return ResponseEntity.ok(service.findByRubroId(rubroId));
+        } catch (RubroListaPrecioException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<RubroListaPrecio> addOrUpdate(@RequestBody RubroListaPrecio rubroListaPrecio) {
+        return ResponseEntity.ok(service.addOrUpdate(rubroListaPrecio));
+    }
+
+}

--- a/src/main/java/eterea/core/service/kotlin/exception/RubroListaPrecioException.kt
+++ b/src/main/java/eterea/core/service/kotlin/exception/RubroListaPrecioException.kt
@@ -1,0 +1,3 @@
+package eterea.core.service.kotlin.exception
+
+class RubroListaPrecioException(rubroId: Long) : RuntimeException("Cannot find Rubro $rubroId")

--- a/src/main/java/eterea/core/service/kotlin/model/ArticuloListaPrecio.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/ArticuloListaPrecio.kt
@@ -16,7 +16,7 @@ data class ArticuloListaPrecio (
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    var articuloListaPrecioId: String? = null,
+    var articuloListaPrecioId: UUID? = null,
     var articuloId: String? = null,
     var publicar: Byte = 0,
 
@@ -27,12 +27,12 @@ data class ArticuloListaPrecio (
 ) : Auditable() {
 
     class Builder {
-        private var articuloListaPrecioId: String? = null
+        private var articuloListaPrecioId: UUID? = null
         private var articuloId: String? = null
         private var publicar: Byte = 0
         private var articulo: Articulo? = null
 
-        fun articuloListaPrecioId(articuloListaPrecioId: String?) = apply { this.articuloListaPrecioId = articuloListaPrecioId }
+        fun articuloListaPrecioId(articuloListaPrecioId: UUID?) = apply { this.articuloListaPrecioId = articuloListaPrecioId }
         fun articuloId(articuloId: String?) = apply { this.articuloId = articuloId }
         fun publicar(publicar: Byte) = apply { this.publicar = publicar }
         fun articulo(articulo: Articulo?) = apply { this.articulo = articulo }

--- a/src/main/java/eterea/core/service/kotlin/model/Rubro.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/Rubro.kt
@@ -1,0 +1,30 @@
+package eterea.core.service.kotlin.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "articulosrubros")
+data class Rubro(
+
+    @Id
+    @Column(name = "codigo")
+    var rubroId: Long? = null,
+
+    @Column(name = "aru_neg_id")
+    var negocioId: Int? = null,
+
+    var descripcion: String? = null,
+
+    @Column(name = "unegocio")
+    var unidadNegocio: Int? = null,
+
+    @Column(name = "aru_restaurant")
+    var restaurant: Byte = 0,
+
+    @Column(name = "aru_prv_id")
+    var proveedorId: Long? = null,
+
+) : Auditable()

--- a/src/main/java/eterea/core/service/kotlin/model/RubroListaPrecio.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/RubroListaPrecio.kt
@@ -1,0 +1,29 @@
+package eterea.core.service.kotlin.model
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.util.UUID
+
+@Entity
+@Table(uniqueConstraints = [UniqueConstraint(columnNames = ["rubroId"])])
+data class RubroListaPrecio(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    var rubroListaPrecioId: UUID? = null,
+
+    var rubroId: Long? = null,
+    var etiqueta: String = "",
+    var publicar: Byte = 0,
+
+    @OneToOne
+    @JoinColumn(name = "rubroId", insertable = false, updatable = false)
+    var rubro: Rubro? = null
+
+) : Auditable()

--- a/src/main/java/eterea/core/service/kotlin/repository/ArticuloListaPrecioRepository.kt
+++ b/src/main/java/eterea/core/service/kotlin/repository/ArticuloListaPrecioRepository.kt
@@ -6,8 +6,9 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.math.BigDecimal
 import java.util.Optional
+import java.util.UUID
 
-interface ArticuloListaPrecioRepository : JpaRepository<ArticuloListaPrecio, String> {
+interface ArticuloListaPrecioRepository : JpaRepository<ArticuloListaPrecio, UUID> {
 
     fun findAllByPublicarAndArticuloPrecioVentaConIvaGreaterThan(
         publicar: Byte, 
@@ -16,4 +17,12 @@ interface ArticuloListaPrecioRepository : JpaRepository<ArticuloListaPrecio, Str
     ): Page<ArticuloListaPrecio>
 
     fun findByArticuloId(articuloId: String): Optional<ArticuloListaPrecio?>?
+
+    fun findAllByPublicarAndArticuloPrecioVentaConIvaGreaterThanAndArticuloRubroId(
+        publicar: Byte,
+        precioVentaConIva: BigDecimal,
+        rubroId: Long,
+        pageable: Pageable
+    ): Page<ArticuloListaPrecio>
+    
 }

--- a/src/main/java/eterea/core/service/kotlin/repository/RubroListaPrecioRepository.kt
+++ b/src/main/java/eterea/core/service/kotlin/repository/RubroListaPrecioRepository.kt
@@ -1,0 +1,15 @@
+package eterea.core.service.kotlin.repository
+
+import eterea.core.service.kotlin.model.RubroListaPrecio
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface RubroListaPrecioRepository : JpaRepository<RubroListaPrecio?, Long?> {
+
+    fun findAllByOrderByRubroDescripcion(): List<RubroListaPrecio>
+
+    fun findAllByPublicarOrderByRubroDescripcion(publicar: Byte): List<RubroListaPrecio>
+
+    fun findByRubroId(rubroId: Long?): Optional<RubroListaPrecio>
+
+}

--- a/src/main/java/eterea/core/service/service/ArticuloListaPrecioService.java
+++ b/src/main/java/eterea/core/service/service/ArticuloListaPrecioService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -61,6 +62,38 @@ public class ArticuloListaPrecioService {
             logArticuloListaPrecio(articuloListaPrecio);
             return articuloListaPrecio;
         });
+    }
+
+    public Page<ArticuloListaPrecio> findAllByRubroIdPaginated(Integer rubroId, Pageable pageable) {
+        Sort sort = Sort.by("articulo.descripcion").ascending();
+        
+        Pageable pageableWithSort = PageRequest.of(
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            sort
+        );
+        
+        return repository.findAllByPublicarAndArticuloPrecioVentaConIvaGreaterThanAndArticuloRubroId(
+            (byte) 1, 
+            BigDecimal.ZERO,
+            rubroId,
+            pageableWithSort
+        );
+    }
+
+    public ArticuloListaPrecio addOrUpdate(ArticuloListaPrecio articuloListaPrecio) {
+        // Buscar si existe un registro con el mismo articuloId
+        Optional<ArticuloListaPrecio> existingArticulo = repository.findByArticuloId(Objects.requireNonNull(articuloListaPrecio.getArticuloId()));
+
+        if (existingArticulo.isPresent()) {
+            // Actualizar el registro existente
+            ArticuloListaPrecio existing = existingArticulo.get();
+            existing.setPublicar(articuloListaPrecio.getPublicar());
+            return repository.save(existing);
+        } else {
+            // Crear nuevo registro
+            return repository.save(articuloListaPrecio);
+        }
     }
 
     private void logArticuloListaPrecio(ArticuloListaPrecio articuloListaPrecio) {

--- a/src/main/java/eterea/core/service/service/RubroListaPrecioService.java
+++ b/src/main/java/eterea/core/service/service/RubroListaPrecioService.java
@@ -1,0 +1,48 @@
+package eterea.core.service.service;
+
+import eterea.core.service.kotlin.exception.RubroListaPrecioException;
+import eterea.core.service.kotlin.model.RubroListaPrecio;
+import eterea.core.service.kotlin.repository.RubroListaPrecioRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+public class RubroListaPrecioService {
+
+    private final RubroListaPrecioRepository repository;
+
+    public RubroListaPrecioService(RubroListaPrecioRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<RubroListaPrecio> findAll() {
+        return repository.findAllByOrderByRubroDescripcion();
+    }
+
+    public List<RubroListaPrecio> findAllByPublicar() {
+        return repository.findAllByPublicarOrderByRubroDescripcion((byte) 1);
+    }
+
+    public RubroListaPrecio findByRubroId(Long rubroId) {
+        return Objects.requireNonNull(repository.findByRubroId(rubroId)).orElseThrow(() -> new RubroListaPrecioException(rubroId));
+    }
+
+    public RubroListaPrecio addOrUpdate(RubroListaPrecio rubroListaPrecio) {
+        // Buscar si existe un registro con el mismo rubroId
+        Optional<RubroListaPrecio> existingRubro = repository.findByRubroId(rubroListaPrecio.getRubroId());
+        
+        if (existingRubro.isPresent()) {
+            // Actualizar el registro existente
+            RubroListaPrecio existing = existingRubro.get();
+            existing.setEtiqueta(rubroListaPrecio.getEtiqueta());
+            existing.setPublicar(rubroListaPrecio.getPublicar());
+            return repository.save(existing);
+        } else {
+            // Crear nuevo registro
+            return repository.save(rubroListaPrecio);
+        }
+    }
+}

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -36,6 +36,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+    open-in-view: false
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
- Agregar soporte HATEOAS:
  - Configurar HAL como formato hipermedia
  - Implementar EntityModel y CollectionModel
  - Agregar enlaces de navegación entre recursos
  - Configurar paginación global (max 100 items)

- Mejorar gestión de rubros:
  - Crear modelo Rubro y RubroListaPrecio
  - Implementar RubroListaPrecioController
  - Agregar endpoints CRUD
  - Manejar excepciones específicas

- Optimizar gestión de artículos:
  - Migrar IDs a UUID
  - Agregar búsqueda por rubro
  - Mejorar paginación y ordenamiento
  - Implementar operaciones CRUD

- Mejoras técnicas:
  - Desactivar Open Session in View
  - Configurar manejo de errores HTTP
  - Optimizar validaciones de entidades
  - Agregar documentación HAL

BREAKING CHANGES:
- ArticuloListaPrecio.articuloListaPrecioId ahora usa UUID
- Las respuestas ahora incluyen enlaces HAL
- La paginación tiene límite de 100 items

Closes #67