### PR TITLE
fix(api): mejorar manejo de errores y logging en impresión fiscal

### DIFF
--- a/src/main/java/eterea/core/service/controller/ComprobanteController.java
+++ b/src/main/java/eterea/core/service/controller/ComprobanteController.java
@@ -5,6 +5,7 @@ package eterea.core.service.controller;
 
 import java.util.List;
 
+import eterea.core.service.exception.ComprobanteException;
 import eterea.core.service.kotlin.model.Comprobante;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import eterea.core.service.service.ComprobanteService;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * @author daniel
@@ -43,6 +45,11 @@ public class ComprobanteController {
 
 	@GetMapping("/{comprobanteId}")
 	public ResponseEntity<Comprobante> findByComprobanteId(@PathVariable Integer comprobanteId) {
-		return new ResponseEntity<>(service.findByComprobanteId(comprobanteId), HttpStatus.OK);
+		try {
+			return new ResponseEntity<>(service.findByComprobanteId(comprobanteId), HttpStatus.OK);
+		} catch (ComprobanteException e) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+		}
 	}
+
 }

--- a/src/main/java/eterea/core/service/controller/facade/ImpresionFiscalController.java
+++ b/src/main/java/eterea/core/service/controller/facade/ImpresionFiscalController.java
@@ -28,14 +28,14 @@ public class ImpresionFiscalController {
 	@GetMapping("/fiscal/{ipAddress}/{hWnd}/{clienteId}/{comprobanteId}/{comprobanteOrigenId}")
 	public ResponseEntity<ImpresionFiscalDto> getData(@PathVariable String ipAddress, @PathVariable Long hWnd,
                                                       @PathVariable Long clienteId, @PathVariable Integer comprobanteId, @PathVariable Long comprobanteOrigenId) {
-		return new ResponseEntity<ImpresionFiscalDto>(
+		return new ResponseEntity<>(
 				service.getData(ipAddress, hWnd, clienteId, comprobanteId, comprobanteOrigenId), HttpStatus.OK);
 	}
 
 	@GetMapping("/fiscalPrevio/{clienteMovimientoPrevioId}/{comprobanteId}/{comprobanteOrigenId}")
 	public ResponseEntity<ImpresionFiscalDto> getDataPrevio(@PathVariable Long clienteMovimientoPrevioId,
                                                             @PathVariable Integer comprobanteId, @PathVariable Long comprobanteOrigenId) {
-		return new ResponseEntity<ImpresionFiscalDto>(
+		return new ResponseEntity<>(
 				service.getDataPrevio(clienteMovimientoPrevioId, comprobanteId, comprobanteOrigenId), HttpStatus.OK);
 	}
 

--- a/src/main/java/eterea/core/service/kotlin/model/ClienteMovimientoPrevio.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/ClienteMovimientoPrevio.kt
@@ -32,7 +32,7 @@ data class ClienteMovimientoPrevio(
     @JoinColumn(name = "clienteId", insertable = false, updatable = false)
     var cliente: Cliente? = null,
 
-    @OneToMany
+    @OneToMany(fetch = FetchType.EAGER)
     @JoinColumn(name = "clientemovimientoprevio_id", insertable = false, updatable = false)
     var articuloMovimientoPrevios: List<ArticuloMovimientoPrevio>? = null
 

--- a/src/main/java/eterea/core/service/service/ComprobanteService.java
+++ b/src/main/java/eterea/core/service/service/ComprobanteService.java
@@ -5,6 +5,7 @@ package eterea.core.service.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,7 +35,7 @@ public class ComprobanteService {
 	}
 
 	public List<Integer> findAllDisponibles() {
-		Comprobante firstComprobante = repository.findFirstByOrderByComprobanteId().orElseThrow(ComprobanteException::new);
+		Comprobante firstComprobante = Objects.requireNonNull(repository.findFirstByOrderByComprobanteId()).orElseThrow(ComprobanteException::new);
         try {
             log.debug("First comprobante: {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(firstComprobante));
         } catch (JsonProcessingException e) {
@@ -76,7 +77,8 @@ public class ComprobanteService {
 	}
 
 	public Comprobante findByComprobanteId(Integer comprobanteId) {
-		return repository.findByComprobanteId(comprobanteId)
+		log.debug("Processing ComprobanteService.findByComprobanteId");
+		return Objects.requireNonNull(repository.findByComprobanteId(comprobanteId))
 				.orElseThrow(() -> new ComprobanteException(comprobanteId));
 	}
 

--- a/src/main/java/eterea/core/service/service/facade/ImpresionFiscalService.java
+++ b/src/main/java/eterea/core/service/service/facade/ImpresionFiscalService.java
@@ -53,35 +53,54 @@ public class ImpresionFiscalService {
 						comprobante.getLetraComprobante()),
 				clienteService.findByClienteId(clienteId), comprobante,
 				articuloMovimientoTemporalService.findAllByHwnd(ipAddress, hWnd, null), clienteMovimiento, null);
-		try {
-			log.debug("ImpresionFiscal -> {}", JsonMapper.builder().findAndAddModules().build()
-					.writerWithDefaultPrettyPrinter().writeValueAsString(impresionFiscal));
-		} catch (JsonProcessingException e) {
-			log.debug("Exception in ImpresionFiscal object");
-		}
+		logImpresionFiscal(impresionFiscal);
 		return impresionFiscal;
 	}
 
 	public ImpresionFiscalDto getDataPrevio(Long clienteMovimientoPrevioId, Integer comprobanteId,
                                             Long comprobanteOrigenId) {
 		Comprobante comprobante = comprobanteService.findByComprobanteId(comprobanteId);
+		logComprobante(comprobante);
 		ClienteMovimiento clienteMovimiento = null;
 		if (comprobanteOrigenId > 0) {
 			clienteMovimiento = clienteMovimientoService.findByClienteMovimientoId(comprobanteOrigenId);
 		}
 		ClienteMovimientoPrevio clienteMovimientoPrevio = clienteMovimientoPrevioService
 				.findByClienteMovimientoPrevioId(clienteMovimientoPrevioId);
+		logClienteMovimientoPrevio(clienteMovimientoPrevio);
 		ImpresionFiscalDto impresionFiscal = new ImpresionFiscalDto(
 				clienteMovimientoService.nextNumeroFactura(comprobante.getPuntoVenta(),
 						comprobante.getLetraComprobante()),
 				clienteMovimientoPrevio.getCliente(), comprobante, null, clienteMovimiento, clienteMovimientoPrevio);
+		logImpresionFiscal(impresionFiscal);
+		return impresionFiscal;
+	}
+
+	private void logClienteMovimientoPrevio(ClienteMovimientoPrevio clienteMovimientoPrevio) {
+		try {
+			log.debug("ClienteMovimientoPrecio -> {}", JsonMapper.builder().findAndAddModules().build()
+					.writerWithDefaultPrettyPrinter().writeValueAsString(clienteMovimientoPrevio));
+		} catch (JsonProcessingException e) {
+			log.debug("ClienteMovimientoPrevio jsonify error -> {}", e.getMessage());
+		}
+	}
+
+	private void logComprobante(Comprobante comprobante) {
+		try {
+			log.debug("Comprobante -> {}", JsonMapper.builder().findAndAddModules().build()
+					.writerWithDefaultPrettyPrinter().writeValueAsString(comprobante));
+		} catch (JsonProcessingException e) {
+			log.debug("Comprobante jsonify error -> {}", e.getMessage());
+		}
+	}
+
+	private void logImpresionFiscal(ImpresionFiscalDto impresionFiscal) {
 		try {
 			log.debug("ImpresionFiscal -> {}", JsonMapper.builder().findAndAddModules().build()
 					.writerWithDefaultPrettyPrinter().writeValueAsString(impresionFiscal));
 		} catch (JsonProcessingException e) {
 			log.debug("Exception in ImpresionFiscal object");
 		}
-		return impresionFiscal;
 	}
 
 }


### PR DESCRIPTION
- Optimizar manejo de errores HTTP:
  - Agregar ResponseStatusException en ComprobanteController
  - Validar objetos nulos con Objects.requireNonNull()
  - Mejorar propagación de excepciones específicas

- Refactorizar logging en ImpresionFiscalService:
  - Extraer logClienteMovimientoPrevio()
  - Extraer logComprobante()
  - Extraer logImpresionFiscal()
  - Mejorar mensajes de error en JsonProcessingException

- Resolver LazyInitializationException:
  - Cambiar fetch type a EAGER en ClienteMovimientoPrevio
  - Optimizar carga de articuloMovimientoPrevios
  - Prevenir errores de serialización JSON

- Limpiar código:
  - Remover sintaxis redundante en ResponseEntity
  - Mejorar formato y legibilidad
  - Agregar logging de debug en servicios críticos

BREAKING CHANGE: ClienteMovimientoPrevio.articuloMovimientoPrevios ahora usa FetchType.EAGER

Closes #69