### PR TITLE
refactor(monedas): optimizar manejo de cotizaciones y precisión decimal

### DIFF
--- a/src/main/java/eterea/core/service/kotlin/model/MonedaCotizacion.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/MonedaCotizacion.kt
@@ -22,7 +22,7 @@ data class MonedaCotizacion(
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
-    var cotizacion: BigDecimal? = null,
+    var cotizacion: Double? = null,
     var copia: Byte = 0
 
 ) : Auditable()

--- a/src/main/java/eterea/core/service/kotlin/model/dto/ArticuloDto.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/dto/ArticuloDto.kt
@@ -2,7 +2,7 @@ package eterea.core.service.kotlin.model.dto
 
 import java.math.BigDecimal
 
-data class ArticuloDto private constructor(
+data class ArticuloDto (
 
     val articuloId: String?,
     val negocioId: Int?,

--- a/src/main/java/eterea/core/service/kotlin/repository/CuentaMovimientoAperturaMonedaRepository.kt
+++ b/src/main/java/eterea/core/service/kotlin/repository/CuentaMovimientoAperturaMonedaRepository.kt
@@ -21,7 +21,7 @@ interface CuentaMovimientoAperturaMonedaRepository : JpaRepository<CuentaMovimie
             m.mca_nrocomp, 
             m.mca_item, 
             c.moneda_id, 
-            ROUND(m.mca_Importe / c.cotizacion, 4), 
+            ROUND(m.mca_Importe / c.cotizacion, 5), 
             NOW()
         FROM movconapertura m
         JOIN moneda_cotizacion c ON m.mca_fecha = c.fecha

--- a/src/main/java/eterea/core/service/kotlin/repository/CuentaMovimientoMonedaRepository.kt
+++ b/src/main/java/eterea/core/service/kotlin/repository/CuentaMovimientoMonedaRepository.kt
@@ -21,7 +21,7 @@ interface CuentaMovimientoMonedaRepository : JpaRepository<CuentaMovimientoMoned
             m.nrocomp, 
             m.item, 
             c.moneda_id, 
-            ROUND(m.Importe / c.cotizacion, 4), 
+            ROUND(m.Importe / c.cotizacion, 5), 
             NOW()
         FROM movcon m
         JOIN moneda_cotizacion c ON m.fecha = c.fecha

--- a/src/main/java/eterea/core/service/repository/MonedaCotizacionRepository.java
+++ b/src/main/java/eterea/core/service/repository/MonedaCotizacionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -15,4 +16,6 @@ public interface MonedaCotizacionRepository extends JpaRepository<MonedaCotizaci
 
     boolean existsByMonedaIdAndFecha(Integer monedaId, OffsetDateTime fecha);
 
+    Optional<MonedaCotizacion> findByMonedaIdAndFecha(Integer monedaId, OffsetDateTime fechaActual);
+    
 }


### PR DESCRIPTION
- Cambiar tipo de cotización:
  - MonedaCotizacion.cotizacion: BigDecimal? -> Double?
  - Actualizar constructores y builders
  - Adaptar valores por defecto (BigDecimal.ONE -> 1.0)

- Aumentar precisión decimal:
  - CuentaMovimientoMonedaRepository: ROUND(4) -> ROUND(5)
  - CuentaMovimientoAperturaMonedaRepository: ROUND(4) -> ROUND(5)
  - Mejorar exactitud en cálculos financieros

- Mejorar logging en MonedaCotizacionService:
  - Agregar logDetalleCotizacion()
  - Logging de conversiones ARS <-> moneda
  - Mejorar mensajes de error

- Optimizar código:
  - Remover constructor privado de ArticuloDto
  - Extraer variable cotizacion para mejor legibilidad
  - Agregar anotación @Slf4j

BREAKING CHANGES:
- MonedaCotizacion.cotizacion ahora usa Double en lugar de BigDecimal
- Aumentada precisión decimal en cálculos de movimientos de 4 a 5 decimales

Closes #71