### PR TITLE
refactor(comprobantes): optimizar control de comprobantes faltantes y…

### DIFF
--- a/src/main/java/eterea/core/service/kotlin/model/ComprobanteFaltante.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/ComprobanteFaltante.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -38,9 +39,11 @@ data class ComprobanteFaltante(
     var numero: Long = 0,
 
     @OneToOne(optional = true)
+    @JoinColumn(name = "cfa_neg_id", insertable = false, updatable = false)
     var negocio: Negocio? = null,
 
     @OneToOne(optional = true)
+    @JoinColumn(name = "cfa_cmp_id", insertable = false, updatable = false)
     var comprobante: Comprobante? = null
 
 ) : Auditable() {

--- a/src/main/java/eterea/core/service/repository/ClienteMovimientoRepository.java
+++ b/src/main/java/eterea/core/service/repository/ClienteMovimientoRepository.java
@@ -27,7 +27,7 @@ public interface ClienteMovimientoRepository extends JpaRepository<ClienteMovimi
 
 	List<ClienteMovimiento> findAllByReservaId(Long reservaId);
 
-	List<ClienteMovimiento> findAllByFechaComprobanteAndComprobanteLibroIva(OffsetDateTime fechaComprobante, Byte libroIva);
+	List<ClienteMovimiento> findAllByFechaComprobanteAndPuntoVentaGreaterThanAndComprobanteLibroIva(OffsetDateTime fechaComprobante, Integer puntoVenta, Byte libroIva);
 
 	List<ClienteMovimiento> findAllByLetraComprobanteAndReciboAndPuntoVentaAndNumeroComprobanteBetweenAndComprobanteDebita(String letraComprobante, Byte recibo, Integer puntoVenta, Long numeroComprobanteDesde, Long numeroComprobanteHasta, Byte debita);
 

--- a/src/main/java/eterea/core/service/service/ClienteMovimientoService.java
+++ b/src/main/java/eterea/core/service/service/ClienteMovimientoService.java
@@ -44,7 +44,7 @@ public class ClienteMovimientoService {
 	}
 
 	public List<ClienteMovimiento> findAllFacturadosByFecha(OffsetDateTime fecha) {
-		return repository.findAllByFechaComprobanteAndComprobanteLibroIva(fecha, (byte) 1);
+		return repository.findAllByFechaComprobanteAndPuntoVentaGreaterThanAndComprobanteLibroIva(fecha, 0, (byte) 1);
 	}
 
 	public List<ClienteMovimiento> findAllFacturasByRango(String letraComprobante, Byte debita, Integer puntoVenta, Long numeroComprobanteDesde, Long numeroComprobanteHasta) {

--- a/src/main/java/eterea/core/service/service/ComprobanteFaltanteService.java
+++ b/src/main/java/eterea/core/service/service/ComprobanteFaltanteService.java
@@ -23,7 +23,6 @@ public class ComprobanteFaltanteService {
                             Integer prefijo,
                             Long numeroComprobante) {
         return new ComprobanteFaltante.Builder()
-                .comprobanteFaltanteId(null)
                 .negocioId(negocioId)
                 .comprobanteId(comprobanteId)
                 .fecha(fechaComprobante)


### PR DESCRIPTION
… mapeo JPA

* fix: agregar @JoinColumn en ComprobanteFaltante para mapeo correcto
  - cfa_neg_id para relación con Negocio
  - cfa_cmp_id para relación con Comprobante
* refactor: optimizar búsqueda de comprobantes por punto de venta
  - agregar filtro puntoVenta > 0 en repository
  - actualizar método en ClienteMovimientoService
* refactor: mejorar agrupación en ConsolidadoService
  - incluir comprobanteAfipId en clave de agrupación
  - optimizar logging mostrando solo min/max de comprobantes
* chore: eliminar inicialización redundante de ID en Builder

La optimización mejora la precisión del control de comprobantes faltantes y el rendimiento de las consultas, además de proporcionar logs más legibles.

Closes #85