### PR TITLE
feat(models): add @Builder.Default annotations to model fields

### DIFF
--- a/src/main/java/eterea/core/service/model/ClienteMovimiento.java
+++ b/src/main/java/eterea/core/service/model/ClienteMovimiento.java
@@ -29,9 +29,11 @@ public class ClienteMovimiento extends Auditable {
     private Integer comprobanteId;
 
     @Column(name = "prefijo")
+    @Builder.Default
     private Integer puntoVenta = 0;
 
     @Column(name = "nrocomprob")
+    @Builder.Default
     private Long numeroComprobante = 0L;
 
     @Column(name = "fechacomprob")
@@ -39,7 +41,8 @@ public class ClienteMovimiento extends Auditable {
     private OffsetDateTime fechaComprobante;
 
     @Column(name = "cgoclie")
-    private Long clienteId;
+    @Builder.Default
+    private Long clienteId = 0L;
 
     private Integer legajoId;
 
@@ -48,25 +51,34 @@ public class ClienteMovimiento extends Auditable {
     private OffsetDateTime fechaVencimiento;
 
     @Column(name = "mcl_neg_id")
-    private Integer negocioId;
+    @Builder.Default
+    private Integer negocioId = 0;
 
     @Column(name = "mcl_emp_id")
-    private Integer empresaId;
+    @Builder.Default
+    private Integer empresaId = 0;
 
+    @Builder.Default
     private BigDecimal importe = BigDecimal.ZERO;
+    @Builder.Default
     private BigDecimal cancelado = BigDecimal.ZERO;
+    @Builder.Default
     private BigDecimal neto = BigDecimal.ZERO;
 
     @Column(name = "netocancelado")
+    @Builder.Default
     private BigDecimal netoCancelado = BigDecimal.ZERO;
 
     @Column(name = "montoiva")
+    @Builder.Default
     private BigDecimal montoIva = BigDecimal.ZERO;
 
     @Column(name = "montoivarni")
+    @Builder.Default
     private BigDecimal montoIvaRni = BigDecimal.ZERO;
 
     @Column(name = "reintegroturista")
+    @Builder.Default
     private BigDecimal reintegroTurista = BigDecimal.ZERO;
 
     @Column(name = "fechareg")
@@ -74,68 +86,89 @@ public class ClienteMovimiento extends Auditable {
     private OffsetDateTime fechaContable;
 
     @Column(name = "nrocompconta")
+    @Builder.Default
     private Integer ordenContable = 0;
 
+    @Builder.Default
     private Byte recibo = 0;
 
     @Column(name = "mcl_asignado")
+    @Builder.Default
     private Byte asignado = 0;
 
+    @Builder.Default
     private Byte anulada = 0;
+
+    @Builder.Default
     private Byte decreto104316 = 0;
 
     @Column(name = "tipocompro")
     private String letraComprobante;
 
     @Column(name = "montoexento")
+    @Builder.Default
     private BigDecimal montoExento = BigDecimal.ZERO;
 
     @Column(name = "nroreserva")
-    private Long reservaId;
+    @Builder.Default
+    private Long reservaId = 0L;
 
     @Column(name = "ctacte")
+    @Builder.Default
     private BigDecimal montoCuentaCorriente = BigDecimal.ZERO;
 
     @Column(name = "mcl_cic_id")
+    @Builder.Default
     private Long cierreCajaId = 0L;
 
     @Column(name = "mcl_cir_id")
+    @Builder.Default
     private Long cierreRestaurantId = 0L;
 
     @Column(name = "mcl_nivel")
+    @Builder.Default
     private Integer nivel = 0;
 
     @Column(name = "mcl_eliminar")
+    @Builder.Default
     private Byte eliminar = 0;
 
     @Column(name = "mcl_ctacte")
+    @Builder.Default
     private Byte cuentaCorriente = 0;
 
     @Column(name = "mcl_letras")
+    @Builder.Default
     private String letras = "";
 
     @Column(name = "mcl_cae")
+    @Builder.Default
     private String cae = "";
 
     @Column(name = "mcl_caevenc")
+    @Builder.Default
     private String caeVencimiento = "";
 
     @Column(name = "mcl_barras")
+    @Builder.Default
     private String codigoBarras = "";
 
     @Column(name = "mcl_particip")
+    @Builder.Default
     private BigDecimal participacion = BigDecimal.ZERO;
 
     @Column(name = "mcl_mon_id")
     private Integer monedaId;
 
     @Column(name = "mcl_cotiz")
+    @Builder.Default
     private BigDecimal cotizacion = BigDecimal.ZERO;
 
     private String observaciones;
     private String trackUuid;
 
     @Column(name = "clavev")
+    @Builder.Default
     private Long clienteMovimientoIdSlave = 0L;
 
     @OneToOne(optional = true)

--- a/src/main/java/eterea/core/service/model/CuentaMovimiento.java
+++ b/src/main/java/eterea/core/service/model/CuentaMovimiento.java
@@ -30,51 +30,72 @@ public class CuentaMovimiento extends Auditable {
     private OffsetDateTime fecha;
 
     @Column(name = "nrocomp")
-    private Integer orden;
+    @Builder.Default
+    private Integer orden = 0;
 
-    private Integer item;
+    @Builder.Default
+    private Integer item = 0;
+
+    @Builder.Default
     private Byte debita = 0;
 
     @Column(name = "mco_neg_id")
-    private Integer negocioId;
+    @Builder.Default
+    private Integer negocioId = 0;
 
     @Column(name = "cuenta")
-    private Long numeroCuenta;
+    @Builder.Default
+    private Long numeroCuenta = 0L;
 
     @Column(name = "cgotcomp")
-    private Integer comprobanteId;
+    @Builder.Default
+    private Integer comprobanteId = 0;
 
-    private String concepto;
+    @Builder.Default
+    private String concepto = "";
+
+    @Builder.Default
     private BigDecimal importe = BigDecimal.ZERO;
 
     @Column(name = "cgosub")
-    private Long subrubroId;
+    @Builder.Default
+    private Long subrubroId = 0L;
 
     @Column(name = "cgoprov")
+    @Builder.Default
     private Long proveedorId = 0L;
 
     @Column(name = "cgoclie")
-    private Long clienteId;
+    @Builder.Default
+    private Long clienteId = 0L;
 
     private Integer legajoId;
 
     @Column(name = "mco_cic_id")
+    @Builder.Default
     private Long cierreCajaId = 0L;
 
     @Column(name = "mco_nivel")
+    @Builder.Default
     private Integer nivel = 0;
 
     @Column(name = "mco_mcf_firma")
+    @Builder.Default
     private Long firma = 0L;
 
     @Column(name = "mco_tas_id")
+    @Builder.Default
     private Integer tipoAsientoId = 0;
 
     @Column(name = "articulomovimiento_id")
+    @Builder.Default
     private Long articuloMovimientoId = 0L;
 
     private Integer ejercicioId;
+
+    @Builder.Default
     private Byte inflacion = 0;
+
     private String trackUuid;
 
     @OneToOne(optional = true)

--- a/src/main/java/eterea/core/service/model/RegistroCae.java
+++ b/src/main/java/eterea/core/service/model/RegistroCae.java
@@ -38,24 +38,31 @@ public class RegistroCae extends Auditable {
     private Integer legajoId;
 
     @Column(name = "rec_cuit")
-    private String cuit;
+    @Builder.Default
+    private String cuit = "";
 
     @Column(name = "rec_total")
+    @Builder.Default
     private BigDecimal total = BigDecimal.ZERO;
 
     @Column(name = "rec_exento")
+    @Builder.Default
     private BigDecimal exento = BigDecimal.ZERO;
 
     @Column(name = "rec_neto")
+    @Builder.Default
     private BigDecimal neto = BigDecimal.ZERO;
 
     @Column(name = "rec_neto105")
+    @Builder.Default
     private BigDecimal neto105 = BigDecimal.ZERO;
 
     @Column(name = "rec_iva")
+    @Builder.Default
     private BigDecimal iva = BigDecimal.ZERO;
 
     @Column(name = "rec_iva105")
+    @Builder.Default
     private BigDecimal iva105 = BigDecimal.ZERO;
 
     @Column(name = "rec_cae")
@@ -68,9 +75,12 @@ public class RegistroCae extends Auditable {
     private String caeVencimiento;
 
     @Column(name = "rec_barras")
+    @Builder.Default
     private String barras = "";
 
     private Integer tipoDocumento;
+
+    @Builder.Default
     private BigDecimal numeroDocumento = BigDecimal.ZERO;
     private Long clienteMovimientoIdAsociado;
     private String trackUuid;


### PR DESCRIPTION
## Descripción
Agregar anotaciones @Builder.Default a los campos de modelos para inicializar valores por defecto. Esto mejora la seguridad en la construcción de objetos al prevenir valores nulos y asegurar una inicialización consistente en los modelos ClienteMovimiento, CuentaMovimiento y RegistroCae.

## Cambios Realizados
- [x] ClienteMovimiento: Inicializar campos BigDecimal a ZERO, campos numéricos a 0/0L y campos String a cadenas vacías
- [x] CuentaMovimiento: Inicializar campos numéricos y BigDecimal con valores por defecto apropiados
- [x] RegistroCae: Inicializar campos BigDecimal a ZERO y campos String a cadenas vacías

## Impacto Potencial
- [x] Cambio potencialmente disruptivo: Los constructores de modelos ahora requieren valores explícitos o usarán valores por defecto, lo que podría afectar el uso existente del Builder

## Verificación
1. `git checkout 141-preparación-para-release-0130---refactorización-de-modelos-y-nuevas-funcionalidades`
2. `mvn compile` para verificar que no hay errores de compilación
3. Ejecutar pruebas unitarias: `mvn test`
4. Verificar que los builders funcionan correctamente con valores por defecto

## Notas Adicionales
Este cambio es parte de la preparación para la release 0.13.0, enfocada en refactorización de modelos y nuevas funcionalidades.