### PR TITLE
feat(models): add @Builder.Default annotations to model fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.12.0] - 2025-10-29
+## [0.13.0] - 2025-10-31
 
 ### Features
 - feat: Nuevo endpoint POST `/clienteMovimiento/` para crear movimientos de cliente

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-2.8.10-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.4.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-0.12.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-0.13.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 
@@ -25,7 +25,7 @@ Servicio Core para la gestión financiera y contable, implementado con una arqui
 
 
 
-# Cambios en la versión 0.12.0
+# Cambios en la versión 0.13.0
 
 - feat: Nuevos endpoints para gestión de movimientos de cliente y búsqueda de legajos
 - refactor: Migración masiva de modelos a Java y refactorización con Lombok

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/model/RegistroCae.java
+++ b/src/main/java/eterea/core/service/model/RegistroCae.java
@@ -82,6 +82,7 @@ public class RegistroCae extends Auditable {
 
     @Builder.Default
     private BigDecimal numeroDocumento = BigDecimal.ZERO;
+
     private Long clienteMovimientoIdAsociado;
     private String trackUuid;
 


### PR DESCRIPTION
Add @Builder.Default annotations to initialize fields with default values in ClienteMovimiento, CuentaMovimiento, and RegistroCae models. This improves object construction safety by preventing null values and ensures consistent initialization.

- ClienteMovimiento: Initialize BigDecimal fields to ZERO, numeric fields to 0/0L, and String fields to empty strings
- CuentaMovimiento: Initialize numeric and BigDecimal fields with appropriate default values
- RegistroCae: Initialize BigDecimal fields to ZERO and String fields to empty strings

BREAKING CHANGE: Model constructors now require explicit values or will use defaults, potentially affecting existing Builder usage.

# Conflicts:
#	src/main/java/eterea/core/service/model/ClienteMovimiento.java #	src/main/java/eterea/core/service/model/CuentaMovimiento.java