### PR TITLE
fix(proveedorMovimiento): corrige orden de sorting en régimen de información de compras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.13.3] - 2025-11-04
+
+### Fixed
+- fix: Corrección del orden de sorting en `ProveedorMovimientoService.findAllByRegimenInformacionCompras` para usar `prefijo` en lugar de `puntoVenta`
+
 ## [0.13.2] - 2025-11-04
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-2.8.10-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.4.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-0.13.2-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-0.13.3-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>0.13.2</version>
+    <version>0.13.3</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/service/ProveedorMovimientoService.java
+++ b/src/main/java/eterea/core/service/service/ProveedorMovimientoService.java
@@ -22,7 +22,7 @@ public class ProveedorMovimientoService {
 
     public List<ProveedorMovimiento> findAllByRegimenInformacionCompras(OffsetDateTime desde, OffsetDateTime hasta) {
         return repository
-                .findAllByFechaContableBetweenAndComprobanteLibroIva(desde, hasta, (byte) 1, Sort.by("fechaComprobante").ascending().and(Sort.by("puntoVenta").ascending().and(Sort.by("numeroComprobante"))))
+                .findAllByFechaContableBetweenAndComprobanteLibroIva(desde, hasta, (byte) 1, Sort.by("fechaComprobante").ascending().and(Sort.by("prefijo").ascending().and(Sort.by("numeroComprobante"))))
                 .stream()
                 .filter(movimiento -> movimiento.getMontoIva().add(movimiento.getMontoIva105().add(movimiento.getMontoIva27())).compareTo(BigDecimal.ZERO) != 0)
                 .toList();


### PR DESCRIPTION
## Descripción
Este PR corrige el orden de sorting en el método `findAllByRegimenInformacionCompras` del servicio `ProveedorMovimientoService`, cambiando el campo utilizado de `puntoVenta` a `prefijo` para mayor consistencia en los resultados. Además, actualiza la versión del proyecto a 0.13.3 y documenta el cambio.

Resuelve la issue #148: "Fix: Corrección en orden de sorting para ProveedorMovimientoService"

## Cambios Realizados
- [x] Corrección del orden de sorting en `ProveedorMovimientoService.java` (línea 25)
- [x] Actualización de versión de 0.13.2 a 0.13.3 en `pom.xml`
- [x] Actualización del CHANGELOG.md con nueva entrada para versión 0.13.3
- [x] Actualización del badge de versión en README.md

## Impacto Potencial
- [x] Cambios mínimos en lógica de ordenamiento que mejoran consistencia sin afectar funcionalidad
- [x] No hay cambios en APIs públicas ni contratos
- [x] No requiere migraciones de base de datos
- [x] Compatible hacia atrás

## Verificación
Para verificar los cambios:
1. `git checkout 148-fix-corrección-en-orden-de-sorting-para-proveedormovimientoservice`
2. `mvn clean compile` - Verificar que el proyecto compile correctamente
3. Revisar el método `findAllByRegimenInformacionCompras` en `ProveedorMovimientoService.java`
4. Verificar que el CHANGELOG.md contenga la nueva entrada para 0.13.3
5. Confirmar que el badge de versión en README.md muestre 0.13.3

## Notas Adicionales
Este es un release patch (0.13.3) que corrige un detalle menor en el ordenamiento de resultados para el régimen de información de compras de proveedores. El cambio mejora la consistencia de los datos devueltos sin introducir breaking changes.