### PR TITLE
feat(proveedor-movimiento): add business name to IVA purchases summary response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.0] - 2026-01-07
+
+### Features
+- feat: Mejora en el endpoint GET `/proveedorMovimiento/resumen/iva/compras/{anho}/{mes}` para incluir el nombre del negocio en la respuesta, basado en cambios en `ProveedorMovimientoController.java`, adición de `ResumenIvaComprasMensualResponse.java` y `ResumenIvaComprasMensualDtoMapper.java`
+
 ## [1.1.0] - 2026-01-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-2.8.10-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.4.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-1.1.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-1.2.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/hexagonal/proveedormovimiento/infrastructure/web/controller/ProveedorMovimientoController.java
+++ b/src/main/java/eterea/core/service/hexagonal/proveedormovimiento/infrastructure/web/controller/ProveedorMovimientoController.java
@@ -4,6 +4,8 @@ import eterea.core.service.hexagonal.proveedormovimiento.application.service.Pro
 import eterea.core.service.hexagonal.proveedormovimiento.domain.model.ProveedorMovimiento;
 import eterea.core.service.hexagonal.proveedormovimiento.domain.model.ResumenIvaComprasMensual;
 import eterea.core.service.hexagonal.proveedormovimiento.infrastructure.web.dto.ProveedorMovimientoNetoAjusteRequest;
+import eterea.core.service.hexagonal.proveedormovimiento.infrastructure.web.dto.ResumenIvaComprasMensualResponse;
+import eterea.core.service.hexagonal.proveedormovimiento.infrastructure.web.mapper.ResumenIvaComprasMensualDtoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import java.util.List;
 public class ProveedorMovimientoController {
 
     private final ProveedorMovimientoService service;
+    private final ResumenIvaComprasMensualDtoMapper resumenIvaComprasMensualDtoMapper;
 
     @GetMapping("/arca/regimen/informacion/compras/{desde}/{hasta}")
     public ResponseEntity<List<ProveedorMovimiento>> findAllByRegimenInformacionCompras(@PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime desde,
@@ -36,8 +39,8 @@ public class ProveedorMovimientoController {
     }
 
     @GetMapping("/resumen/iva/compras/{anho}/{mes}")
-    public ResponseEntity<ResumenIvaComprasMensual> resumenIvaComprasMensual(@PathVariable Integer anho, @PathVariable Integer mes) {
-        return ResponseEntity.ok(service.getResumenIvaComprasMensual(anho, mes));
+    public ResponseEntity<ResumenIvaComprasMensualResponse> resumenIvaComprasMensual(@PathVariable Integer anho, @PathVariable Integer mes) {
+        return ResponseEntity.ok(resumenIvaComprasMensualDtoMapper.toResponse(service.getResumenIvaComprasMensual(anho, mes)));
     }
 
 }

--- a/src/main/java/eterea/core/service/hexagonal/proveedormovimiento/infrastructure/web/dto/ResumenIvaComprasMensualResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/proveedormovimiento/infrastructure/web/dto/ResumenIvaComprasMensualResponse.java
@@ -1,0 +1,29 @@
+package eterea.core.service.hexagonal.proveedormovimiento.infrastructure.web.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResumenIvaComprasMensualResponse {
+
+    private Integer negocioId;
+    private String negocio;
+    private Integer anho;
+    private Integer mes;
+    private BigDecimal neto;
+    private BigDecimal facturadoC;
+    private BigDecimal gastosNoGravados;
+    private BigDecimal iva21;
+    private BigDecimal iva27;
+    private BigDecimal iva105;
+    private BigDecimal percepcionIva;
+    private BigDecimal percepcionIngresosBrutos;
+    private BigDecimal totalCalculado;
+    private BigDecimal total;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/proveedormovimiento/infrastructure/web/mapper/ResumenIvaComprasMensualDtoMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/proveedormovimiento/infrastructure/web/mapper/ResumenIvaComprasMensualDtoMapper.java
@@ -1,0 +1,40 @@
+package eterea.core.service.hexagonal.proveedormovimiento.infrastructure.web.mapper;
+
+import eterea.core.service.hexagonal.negocio.application.service.NegocioService;
+import eterea.core.service.hexagonal.negocio.domain.model.Negocio;
+import eterea.core.service.hexagonal.proveedormovimiento.domain.model.ResumenIvaComprasMensual;
+import eterea.core.service.hexagonal.proveedormovimiento.infrastructure.web.dto.ResumenIvaComprasMensualResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResumenIvaComprasMensualDtoMapper {
+
+    private final NegocioService negocioService;
+
+    public ResumenIvaComprasMensualResponse toResponse(ResumenIvaComprasMensual resumen) {
+        if (resumen == null) {
+            return null;
+        }
+        return ResumenIvaComprasMensualResponse.builder()
+                .negocioId(resumen.getNegocioId())
+                .negocio(negocioService.getNegocioById(resumen.getNegocioId())
+                        .map(Negocio::getNombre)
+                        .orElse(""))
+                .anho(resumen.getAnho())
+                .mes(resumen.getMes())
+                .neto(resumen.getNeto())
+                .facturadoC(resumen.getFacturadoC())
+                .gastosNoGravados(resumen.getGastosNoGravados())
+                .iva21(resumen.getIva21())
+                .iva27(resumen.getIva27())
+                .iva105(resumen.getIva105())
+                .percepcionIva(resumen.getPercepcionIva())
+                .percepcionIngresosBrutos(resumen.getPercepcionIngresosBrutos())
+                .totalCalculado(resumen.getTotalCalculado())
+                .total(resumen.getTotal())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## Descripción
*This PR enhances the IVA purchases summary endpoint by adding the business name (negocio) to the response. This resolves issue #161 by providing more detailed information in the summary.*

## Cambios Realizados
- [x] Updated `ProveedorMovimientoController.java` to use the new response DTO.
- [x] Created `ResumenIvaComprasMensualResponse.java` DTO with the added negocio field.
- [x] Added `ResumenIvaComprasMensualDtoMapper.java` to map the negocio name from NegocioService.
- [x] Updated CHANGELOG.md, README.md, and pom.xml for version bump to 1.2.0.

## Impacto Potencial
- [x] Clients consuming the endpoint may need to update their code to handle the new negocio field in the response.
- [x] No database migrations required.

## Verificación
*To verify the changes:*
1. `git checkout 161-release-v120-enhance-iva-summary-endpoint-with-business-name-and-migrate-negocio-to-hexagonal-architecture`
2. `mvn clean install`
3. Start the application.
4. Make a GET request to `/proveedorMovimiento/resumen/iva/compras/{anho}/{mes}` and check that the response includes the `negocio` field.

## Notas Adicionales
*The negocio name is fetched from NegocioService to provide the business name associated with the IVA summary.*