### PR TITLE
feat(invoicedata): add hexagonal module for complete invoice data retrieval

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -117,6 +117,11 @@ jobs:
                   <div id="legajo-class-diagram"></div>
               </div>
 
+              <div class="section">
+                  <h2>Dominio: Consulta de Datos de Facturación</h2>
+                  <div id="invoicedata-class-diagram"></div>
+              </div>
+
               <div id="dependencies" class="section">
                   <h2>🌳 Grafo de Dependencias</h2>
                   <p>El siguiente es el árbol de dependencias completo del proyecto, generado por Maven.</p>
@@ -189,9 +194,11 @@ jobs:
                       // Provider Domain
                       { id: 'proveedor-class-diagram', path: 'diagrams/mermaid/proveedor-class-diagram.mmd', title: 'UML Diagrama de Clases de Proveedores' },
                       { id: 'proveedor-sequence-diagram', path: 'diagrams/mermaid/proveedor-sequence-diagram.mmd', title: '🔄 Diagrama de Secuencia: Gestión de Proveedor' },
-                      // Legajo Domain
-                      { id: 'legajo-class-diagram', path: 'diagrams/mermaid/legajo-class-diagram.mmd', title: 'UML Diagrama de Clases de Legajos' }
-                  ];
+                       // Legajo Domain
+                       { id: 'legajo-class-diagram', path: 'diagrams/mermaid/legajo-class-diagram.mmd', title: 'UML Diagrama de Clases de Legajos' },
+                       // InvoiceData Domain
+                       { id: 'invoicedata-class-diagram', path: 'diagrams/mermaid/invoicedata-class-diagram.mmd', title: 'UML Diagrama de Clases de Consulta de Datos de Facturación' }
+                   ];
 
                   // Insert titles and mermaid divs first
                   diagramConfigs.forEach(config => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [2.1.0] - 2026-01-31
+
+### Features
+- **feat(invoicedata)**: Nuevo módulo hexagonal `InvoiceData` para consulta de datos de facturación completa
+  - Nuevo endpoint GET `/api/core/invoiceData/{clienteMovimientoId}` para obtener datos completos de factura
+  - Modelo de dominio `InvoiceData` con información de cliente, movimiento, CAE y comprobante asociado
+  - Implementación completa de arquitectura hexagonal:
+    - `domain/`: Modelos y puertos de entrada
+    - `application/`: Servicios y casos de uso
+    - `infrastructure/`: DTOs, mappers y controlador REST
+  - Mappers para transformación de entidades: `InvoiceDataMapper`, `ClienteMovimientoMapper`, `RegistroCaeMapper`, `ArticuloMovimientoMapper`, `ClienteMapper`, `EmpresaMapper`, `ComprobanteMapper`, `ComprobanteAfipMapper`, `MonedaMapper`, `ConceptoFacturadoMapper`
+  - DTOs de respuesta estructurados: `InvoiceDataResponse`, `ClienteMovimientoResponse`, `RegistroCaeResponse`, etc.
+
+### Changed
+- **refactor(stock)**: Simplificación de inyección de dependencias en `StockService` usando `@RequiredArgsConstructor` en lugar de constructor manual
+- **refactor(empresa)**: Adición de método `toResponse()` en `EmpresaMapper` para soporte de DTOs en módulo invoicedata
+- **refactor(model)**: Actualización de `ClienteMovimiento` y `RegistroCae` con nuevas relaciones JPA para soporte de consultas enriquecidas
+
+### Dependencies
+- **chore(deps)**: Actualización de Spring Boot 4.0.1 → 4.0.2
+
 ## [2.0.0] - 2026-01-27
 
 ### 🚀 Major Release - Migración de Legajo a Arquitectura Hexagonal y Actualización de Dependencias

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/javase/jdk25-archive-downloads.html)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.0-blueviolet.svg)](https://kotlinlang.org/)
 
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.1-green.svg)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-green.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-green.svg)](https://spring.io/projects/spring-cloud)
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.1-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.5.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.0.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.1.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 
@@ -31,7 +31,7 @@ Servicio Core para la gestión financiera y contable, implementado con una **arq
 ## Stack Tecnológico
 
 - **Java 25** y **Kotlin 2.3.0**
-- **Spring Boot 4.0.1** con Spring Cloud 2025.1.0
+- **Spring Boot 4.0.2** con Spring Cloud 2025.1.0
 - **Arquitectura Hexagonal** para modularidad y testabilidad
 - **Consul Discovery** y **OpenFeign**
   - Consul Discovery
@@ -61,6 +61,8 @@ El proyecto utiliza una **arquitectura hexagonal** con implementación mixta:
 
 ### Módulos Hexagonales
 - **`hexagonal/empresa/`**: Gestión de empresas con puertos de entrada y salida
+- **`hexagonal/legajo/`**: Gestión de legajos con arquitectura hexagonal
+- **`hexagonal/invoicedata/`**: Consulta de datos completos de facturación con arquitectura hexagonal
 - **`hexagonal/facturacion/arca/nacional/`**: Facturación electrónica nacional
 - **`hexagonal/facturacion/arca/exportacion/`**: Facturación de exportación
 
@@ -87,6 +89,10 @@ El proyecto utiliza una **arquitectura hexagonal** con implementación mixta:
 - **Artículos**: Gestión de artículos y sus listas de precios
 - **Rubros**: Categorización y gestión de rubros comerciales
 - **Inventario**: Control de stock y movimientos
+
+### Consulta de Datos de Facturación
+- **InvoiceData**: Endpoint para obtener datos completos de facturas por movimiento de cliente
+- Integración con módulos de empresa, cliente, comprobante y CAE
 
 ### Servicios Transversales
 - **Service Discovery**: Integración con Consul

--- a/docs/diagrams/mermaid/hexagonal-architecture-diagram.mmd
+++ b/docs/diagrams/mermaid/hexagonal-architecture-diagram.mmd
@@ -26,6 +26,13 @@ graph TB
             L_DOMAIN[Legajo Model<br/>hexagonal.legajo.domain.model]
             L_PORTS[Ports In/Out<br/>hexagonal.legajo.domain.ports]
         end
+
+        subgraph "Consulta de Datos de Facturación"
+            ID_API[InvoiceData Controller<br/>hexagonal.invoicedata.infrastructure.web]
+            ID_APP[InvoiceData Service<br/>hexagonal.invoicedata.application.service]
+            ID_DOMAIN[InvoiceData Model<br/>hexagonal.invoicedata.domain.model]
+            ID_PORTS[Ports In<br/>hexagonal.invoicedata.domain.ports.in]
+        end
         
         subgraph "Persistence Layer"
             E_REPO[Empresa Repository Adapter<br/>hexagonal.empresa.infrastructure.persistence.repository]
@@ -47,6 +54,7 @@ graph TB
         FE_API --> FE_APP
         E_API --> E_APP
         L_API --> L_APP
+        ID_API --> ID_APP
         
         %% Application to Domain
         FN_APP --> FN_DOMAIN
@@ -55,6 +63,8 @@ graph TB
         E_APP --> E_PORTS
         L_APP --> L_DOMAIN
         L_APP --> L_PORTS
+        ID_APP --> ID_DOMAIN
+        ID_APP --> ID_PORTS
         
         %% Domain to Infrastructure
         E_PORTS --> E_REPO
@@ -65,17 +75,23 @@ graph TB
         L_REPO --> L_ENTITY
         L_REPO --> L_MAPPER
         L_ENTITY --> DB
+        ID_PORTS --> DB
         
         %% External Dependencies
         FN_APP --> AFIP
         FE_APP --> AFIP
         E_API --> CONSUL
+        ID_APP --> E_API
         
         style FN_API fill:#e1f5fe
         style FE_API fill:#e1f5fe
         style E_API fill:#e1f5fe
+        style L_API fill:#e1f5fe
+        style ID_API fill:#e1f5fe
         style FN_APP fill:#f3e5f5
         style FE_APP fill:#f3e5f5
         style E_APP fill:#f3e5f5
+        style L_APP fill:#f3e5f5
+        style ID_APP fill:#f3e5f5
         style DB fill:#ffebee
     end

--- a/docs/diagrams/mermaid/invoicedata-class-diagram.mmd
+++ b/docs/diagrams/mermaid/invoicedata-class-diagram.mmd
@@ -1,0 +1,112 @@
+classDiagram
+    direction TB
+
+    class InvoiceDataController {
+        +getInvoiceDatabyClienteMovimientoId(Long): ResponseEntity~InvoiceDataResponse~
+    }
+
+    class InvoiceDataService {
+        +getInvoiceData(Long): InvoiceData
+    }
+
+    class GetInvoiceDataByClienteMovimientoIdImpl {
+        +getInvoiceDataByClienteMovimientoId(Long): InvoiceData
+    }
+
+    class InvoiceData {
+        +clienteMovimiento: ClienteMovimiento
+        +registroCae: RegistroCae
+        +clienteMovimientoAsociado: ClienteMovimiento
+    }
+
+    class InvoiceDataResponse {
+        +clienteMovimiento: ClienteMovimientoResponse
+        +registroCae: RegistroCaeResponse
+        +clienteMovimientoAsociado: ClienteMovimientoResponse
+    }
+
+    class ClienteMovimientoResponse {
+        +letraComprobante: String
+        +puntoVenta: Integer
+        +numeroComprobante: Long
+        +observaciones: String
+        +neto: BigDecimal
+        +montoIva: BigDecimal
+        +importe: BigDecimal
+        +empresa: EmpresaResponse
+        +cliente: ClienteResponse
+        +moneda: MonedaResponse
+        +comprobante: ComprobanteResponse
+        +articulos: List~ArticuloMovimientoResponse~
+    }
+
+    class RegistroCaeResponse {
+        +tipoDocumento: Integer
+        +puntoVenta: Integer
+        +numeroComprobante: Long
+        +cae: String
+        +caeVencimiento: OffsetDateTime
+        +total: BigDecimal
+        +comprobante: ComprobanteResponse
+    }
+
+    class EmpresaResponse {
+        +nombreFantasia: String
+        +razonSocial: String
+        +domicilio: String
+        +telefono: String
+        +condicionIva: String
+        +cuit: String
+        +ingresosBrutos: String
+        +inicioActividades: OffsetDateTime
+    }
+
+    class ClienteResponse {
+        +razonSocial: String
+        +domicilio: String
+        +cuit: String
+        +posicionIva: Integer
+        +email: String
+    }
+
+    class MonedaResponse {
+        +simbolo: String
+    }
+
+    class ComprobanteResponse {
+        +letraComprobante: String
+        +contado: Byte
+        +comprobanteAfip: ComprobanteAfipResponse
+    }
+
+    class ComprobanteAfipResponse {
+        +comprobanteAfipId: Integer
+        +label: String
+    }
+
+    class ArticuloMovimientoResponse {
+        +articuloId: String
+        +cantidad: BigDecimal
+        +precioUnitario: BigDecimal
+        +descripcion: String
+        +conceptoFacturado: ConceptoFacturadoResponse
+    }
+
+    class ConceptoFacturadoResponse {
+        +concepto: String
+    }
+
+    InvoiceDataController --> InvoiceDataService
+    InvoiceDataService --> GetInvoiceDataByClienteMovimientoIdImpl
+    GetInvoiceDataByClienteMovimientoIdImpl --> InvoiceData
+    InvoiceDataController ..> InvoiceDataResponse : uses mapper
+    InvoiceDataResponse --> ClienteMovimientoResponse
+    InvoiceDataResponse --> RegistroCaeResponse
+    ClienteMovimientoResponse --> EmpresaResponse
+    ClienteMovimientoResponse --> ClienteResponse
+    ClienteMovimientoResponse --> MonedaResponse
+    ClienteMovimientoResponse --> ComprobanteResponse
+    ClienteMovimientoResponse --> ArticuloMovimientoResponse
+    RegistroCaeResponse --> ComprobanteResponse
+    ComprobanteResponse --> ComprobanteAfipResponse
+    ArticuloMovimientoResponse --> ConceptoFacturadoResponse

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>

--- a/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/mapper/EmpresaMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/mapper/EmpresaMapper.java
@@ -2,6 +2,7 @@ package eterea.core.service.hexagonal.empresa.infrastructure.persistence.mapper;
 
 import eterea.core.service.hexagonal.empresa.domain.model.Empresa;
 import eterea.core.service.hexagonal.empresa.infrastructure.persistence.entity.EmpresaEntity;
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.EmpresaResponse;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -56,6 +57,22 @@ public class EmpresaMapper {
                 .conectaUnificado(empresa.getConectaUnificado())
                 .certificado(empresa.getCertificado())
                 .businessId(empresa.getBusinessId())
+                .build();
+    }
+
+    public EmpresaResponse toResponse(EmpresaEntity empresaEntity) {
+        if (empresaEntity == null) {
+            return null;
+        }
+        return EmpresaResponse.builder()
+                .nombreFantasia(empresaEntity.getNombreFantasia())
+                .razonSocial(empresaEntity.getRazonSocial())
+                .domicilio(empresaEntity.getDomicilio())
+                .telefono(empresaEntity.getTelefono())
+                .condicionIva(empresaEntity.getCondicionIva())
+                .cuit(empresaEntity.getCuit())
+                .ingresosBrutos(empresaEntity.getIngresosBrutos())
+                .inicioActividades(empresaEntity.getInicioActividades())
                 .build();
     }
 

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/application/service/InvoiceDataService.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/application/service/InvoiceDataService.java
@@ -1,0 +1,20 @@
+package eterea.core.service.hexagonal.invoicedata.application.service;
+
+import eterea.core.service.hexagonal.invoicedata.domain.model.InvoiceData;
+import eterea.core.service.hexagonal.invoicedata.domain.ports.in.GetInvoiceDataByClienteMovimientoId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class InvoiceDataService {
+
+    private final GetInvoiceDataByClienteMovimientoId getInvoiceDataByClienteMovimientoId;
+
+    public InvoiceData getInvoiceData(Long clienteMovimientoId) {
+        return getInvoiceDataByClienteMovimientoId.getInvoiceDataByClienteMovimientoId(clienteMovimientoId);
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/application/usecases/GetInvoiceDataByClienteMovimientoIdImpl.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/application/usecases/GetInvoiceDataByClienteMovimientoIdImpl.java
@@ -1,0 +1,38 @@
+package eterea.core.service.hexagonal.invoicedata.application.usecases;
+
+import eterea.core.service.hexagonal.invoicedata.domain.model.InvoiceData;
+import eterea.core.service.hexagonal.invoicedata.domain.ports.in.GetInvoiceDataByClienteMovimientoId;
+import eterea.core.service.model.ClienteMovimiento;
+import eterea.core.service.service.ClienteMovimientoService;
+import eterea.core.service.service.RegistroCaeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetInvoiceDataByClienteMovimientoIdImpl implements GetInvoiceDataByClienteMovimientoId {
+
+    private final ClienteMovimientoService clienteMovimientoService;
+    private final RegistroCaeService registroCaeService;
+
+    @Override
+    public InvoiceData getInvoiceDataByClienteMovimientoId(Long clienteMovimientoId) {
+        var clienteMovimiento = clienteMovimientoService.findByClienteMovimientoId(clienteMovimientoId);
+        var registroCae = registroCaeService.findByUnique(
+                clienteMovimiento.getComprobanteId(),
+                clienteMovimiento.getPuntoVenta(),
+                clienteMovimiento.getNumeroComprobante());
+        ClienteMovimiento clienteMovimientoAsociado = null;
+        if (registroCae.getClienteMovimientoIdAsociado() != null) {
+            clienteMovimientoAsociado = clienteMovimientoService.findByClienteMovimientoId(registroCae.getClienteMovimientoIdAsociado());
+        }
+
+        return InvoiceData.builder()
+                .clienteMovimiento(clienteMovimiento)
+                .registroCae(registroCae)
+                .clienteMovimientoAsociado(clienteMovimientoAsociado)
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/domain/model/InvoiceData.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/domain/model/InvoiceData.java
@@ -1,0 +1,23 @@
+package eterea.core.service.hexagonal.invoicedata.domain.model;
+
+import eterea.core.service.model.ClienteMovimiento;
+import eterea.core.service.model.RegistroCae;
+import eterea.core.service.tool.Jsonifier;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvoiceData {
+
+    ClienteMovimiento clienteMovimiento;
+    RegistroCae registroCae;
+    ClienteMovimiento clienteMovimientoAsociado;
+
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/domain/ports/in/GetInvoiceDataByClienteMovimientoId.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/domain/ports/in/GetInvoiceDataByClienteMovimientoId.java
@@ -1,0 +1,9 @@
+package eterea.core.service.hexagonal.invoicedata.domain.ports.in;
+
+import eterea.core.service.hexagonal.invoicedata.domain.model.InvoiceData;
+
+public interface GetInvoiceDataByClienteMovimientoId {
+
+    InvoiceData getInvoiceDataByClienteMovimientoId(Long clienteMovimientoId);
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ArticuloMovimientoResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ArticuloMovimientoResponse.java
@@ -1,0 +1,18 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class ArticuloMovimientoResponse {
+
+    private BigDecimal cantidad;
+    private BigDecimal precioUnitarioSinIva;
+    private BigDecimal precioUnitarioConIva;
+    private ArticuloResponse articulo;
+    private ConceptoFacturadoResponse conceptoFacturado;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ArticuloResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ArticuloResponse.java
@@ -1,0 +1,12 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArticuloResponse {
+
+    private String descripcion;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ClienteMovimientoResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ClienteMovimientoResponse.java
@@ -1,0 +1,35 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import eterea.core.service.tool.Jsonifier;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+public class ClienteMovimientoResponse {
+
+    private String letraComprobante;
+    private Integer puntoVenta;
+    private Long numeroComprobante;
+    private String observaciones;
+    private String letras;
+    private Long reservaId;
+    private BigDecimal neto;
+    private BigDecimal montoExento;
+    private BigDecimal montoIva;
+    private BigDecimal montoIvaRni;
+    private BigDecimal importe;
+    private EmpresaResponse empresa;
+    private ClienteResponse cliente;
+    private MonedaResponse moneda;
+    private ComprobanteResponse comprobante;
+    private List<ArticuloMovimientoResponse> articulos;
+
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ClienteResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ClienteResponse.java
@@ -1,0 +1,16 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ClienteResponse {
+
+    private String razonSocial;
+    private String domicilio;
+    private String cuit;
+    private Integer posicionIva;
+    private String email;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ComprobanteAfipResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ComprobanteAfipResponse.java
@@ -1,0 +1,13 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ComprobanteAfipResponse {
+
+    private Integer comprobanteAfipId;
+    private String label;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ComprobanteResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ComprobanteResponse.java
@@ -1,0 +1,14 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ComprobanteResponse {
+
+    private String letraComprobante;
+    private Byte contado;
+    private ComprobanteAfipResponse comprobanteAfip;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ConceptoFacturadoResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/ConceptoFacturadoResponse.java
@@ -1,0 +1,12 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ConceptoFacturadoResponse {
+
+    private String concepto;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/EmpresaResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/EmpresaResponse.java
@@ -1,0 +1,19 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmpresaResponse {
+
+    private String nombreFantasia;
+    private String razonSocial;
+    private String domicilio;
+    private String telefono;
+    private String condicionIva;
+    private String cuit;
+    private String ingresosBrutos;
+    private String inicioActividades;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/InvoiceDataResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/InvoiceDataResponse.java
@@ -1,0 +1,18 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import eterea.core.service.tool.Jsonifier;
+import lombok.*;
+
+@Getter
+@Builder
+public class InvoiceDataResponse {
+
+    ClienteMovimientoResponse clienteMovimiento;
+    RegistroCaeResponse registroCae;
+    ClienteMovimientoResponse clienteMovimientoAsociado;
+
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/MonedaResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/MonedaResponse.java
@@ -1,0 +1,12 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MonedaResponse {
+
+    private String simbolo;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/RegistroCaeResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/RegistroCaeResponse.java
@@ -1,0 +1,23 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class RegistroCaeResponse {
+
+    private Integer tipoDocumento;
+    private Integer puntoVenta;
+    private Integer comprobanteId;
+    private Long numeroComprobante;
+    private BigDecimal total;
+    private BigDecimal numeroDocumento;
+    private String cae;
+    private String caeVencimiento;
+    private String fecha;
+    private ComprobanteResponse comprobante;
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ArticuloMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ArticuloMapper.java
@@ -1,0 +1,19 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.ArticuloResponse;
+import eterea.core.service.kotlin.model.Articulo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArticuloMapper {
+
+    public ArticuloResponse toResponse(Articulo articulo) {
+        if (articulo == null) {
+            return null;
+        }
+        return ArticuloResponse.builder()
+                .descripcion(articulo.getDescripcion())
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ArticuloMovimientoMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ArticuloMovimientoMapper.java
@@ -1,0 +1,40 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.ArticuloMovimientoResponse;
+import eterea.core.service.kotlin.exception.ConceptoFacturadoException;
+import eterea.core.service.kotlin.model.ArticuloMovimiento;
+import eterea.core.service.kotlin.model.ConceptoFacturado;
+import eterea.core.service.service.ConceptoFacturadoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ArticuloMovimientoMapper {
+
+    private final ArticuloMapper articuloMapper;
+    private final ConceptoFacturadoService conceptoFacturadoService;
+    private final ConceptoFacturadoMapper conceptoFacturadoMapper;
+
+    public ArticuloMovimientoResponse toResponse(ArticuloMovimiento articuloMovimiento) {
+        if (articuloMovimiento == null) {
+            return null;
+        }
+        ConceptoFacturado conceptoFacturado = null;
+        try {
+            conceptoFacturado = conceptoFacturadoService.findByArticuloMovimientoId(articuloMovimiento.getArticuloMovimientoId());
+        } catch (ConceptoFacturadoException e) {
+            log.error(e.getMessage());
+        }
+        return ArticuloMovimientoResponse.builder()
+                .cantidad(articuloMovimiento.getCantidad())
+                .precioUnitarioSinIva(articuloMovimiento.getPrecioUnitarioSinIva())
+                .precioUnitarioConIva(articuloMovimiento.getPrecioUnitarioConIva())
+                .articulo(articuloMapper.toResponse(articuloMovimiento.getArticulo()))
+                .conceptoFacturado(conceptoFacturadoMapper.toResponse(conceptoFacturado))
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ClienteMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ClienteMapper.java
@@ -1,0 +1,23 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.ClienteResponse;
+import eterea.core.service.kotlin.model.Cliente;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClienteMapper {
+
+    public ClienteResponse toResponse(Cliente cliente) {
+        if (cliente == null) {
+            return null;
+        }
+        return ClienteResponse.builder()
+                .razonSocial(cliente.getRazonSocial())
+                .domicilio(cliente.getDomicilio())
+                .cuit(cliente.getCuit())
+                .posicionIva(cliente.getPosicionIva())
+                .email(cliente.getEmail())
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ClienteMovimientoMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ClienteMovimientoMapper.java
@@ -1,0 +1,50 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.empresa.infrastructure.persistence.mapper.EmpresaMapper;
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.ClienteMovimientoResponse;
+import eterea.core.service.model.ClienteMovimiento;
+import eterea.core.service.service.ArticuloMovimientoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClienteMovimientoMapper {
+
+    private final EmpresaMapper empresaMapper;
+    private final ClienteMapper clienteMapper;
+    private final MonedaMapper monedaMapper;
+    private final ComprobanteMapper comprobanteMapper;
+    private final ArticuloMovimientoService articuloMovimientoService;
+    private final ArticuloMovimientoMapper articuloMovimientoMapper;
+
+    public ClienteMovimientoResponse toResponse(ClienteMovimiento clienteMovimiento) {
+        if (clienteMovimiento == null) {
+            return null;
+        }
+        return ClienteMovimientoResponse.builder()
+                .letraComprobante(clienteMovimiento.getLetraComprobante())
+                .puntoVenta(clienteMovimiento.getPuntoVenta())
+                .numeroComprobante(clienteMovimiento.getNumeroComprobante())
+                .observaciones(clienteMovimiento.getObservaciones())
+                .letras(clienteMovimiento.getLetras())
+                .reservaId(clienteMovimiento.getReservaId())
+                .neto(clienteMovimiento.getNeto())
+                .montoExento(clienteMovimiento.getMontoExento())
+                .montoIva(clienteMovimiento.getMontoIva())
+                .montoIvaRni(clienteMovimiento.getMontoIvaRni())
+                .importe(clienteMovimiento.getImporte())
+                .empresa(empresaMapper.toResponse(clienteMovimiento.getEmpresa()))
+                .cliente(clienteMapper.toResponse(clienteMovimiento.getCliente()))
+                .moneda(monedaMapper.toResponse(clienteMovimiento.getMoneda()))
+                .comprobante(comprobanteMapper.toResponse(clienteMovimiento.getComprobante()))
+                .articulos(
+                        articuloMovimientoService.findAllByClienteMovimientoId(clienteMovimiento.getClienteMovimientoId())
+                                .stream()
+                                .map(articuloMovimientoMapper::toResponse)
+                                .toList()
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ComprobanteAfipMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ComprobanteAfipMapper.java
@@ -1,0 +1,21 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.ComprobanteAfipResponse;
+import eterea.core.service.kotlin.model.ComprobanteAfip;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ComprobanteAfipMapper {
+
+    public ComprobanteAfipResponse toResponse(@Nullable ComprobanteAfip comprobanteAfip) {
+        if (comprobanteAfip == null) {
+            return null;
+        }
+        return ComprobanteAfipResponse.builder()
+                .comprobanteAfipId(comprobanteAfip.getComprobanteAfipId())
+                .label(comprobanteAfip.getLabel())
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ComprobanteMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ComprobanteMapper.java
@@ -1,0 +1,25 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.ComprobanteResponse;
+import eterea.core.service.kotlin.model.Comprobante;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ComprobanteMapper {
+
+    private final ComprobanteAfipMapper comprobanteAfipMapper;
+
+    public ComprobanteResponse toResponse(Comprobante comprobante) {
+        if (comprobante == null) {
+            return null;
+        }
+        return ComprobanteResponse.builder()
+                .letraComprobante(comprobante.getLetraComprobante())
+                .contado(comprobante.getContado())
+                .comprobanteAfip(comprobanteAfipMapper.toResponse(comprobante.getComprobanteAfip()))
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ConceptoFacturadoMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/ConceptoFacturadoMapper.java
@@ -1,0 +1,19 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.ConceptoFacturadoResponse;
+import eterea.core.service.kotlin.model.ConceptoFacturado;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConceptoFacturadoMapper {
+
+    public ConceptoFacturadoResponse toResponse(ConceptoFacturado conceptoFacturado) {
+        if (conceptoFacturado == null) {
+            return null;
+        }
+        return ConceptoFacturadoResponse.builder()
+                .concepto(conceptoFacturado.getConcepto())
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/InvoiceDataMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/InvoiceDataMapper.java
@@ -1,0 +1,31 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.domain.model.InvoiceData;
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.InvoiceDataResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class InvoiceDataMapper {
+
+    private final ClienteMovimientoMapper clienteMovimientoMapper;
+    private final RegistroCaeMapper registroCaeMapper;
+
+    public InvoiceDataResponse toResponse(InvoiceData invoiceData) {
+        if (invoiceData == null) {
+            return null;
+        }
+        var clienteMovimiento = clienteMovimientoMapper.toResponse(invoiceData.getClienteMovimiento());
+        var registroCae = registroCaeMapper.toResponse(invoiceData.getRegistroCae());
+        var clienteMovimientoAsociado = clienteMovimientoMapper.toResponse(invoiceData.getClienteMovimientoAsociado());
+        return InvoiceDataResponse.builder()
+                .clienteMovimiento(clienteMovimiento)
+                .registroCae(registroCae)
+                .clienteMovimientoAsociado(clienteMovimientoAsociado)
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/MonedaMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/MonedaMapper.java
@@ -1,0 +1,19 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.MonedaResponse;
+import eterea.core.service.kotlin.model.Moneda;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MonedaMapper {
+
+    public MonedaResponse toResponse(Moneda moneda) {
+        if (moneda == null) {
+            return null;
+        }
+        return MonedaResponse.builder()
+                .simbolo(moneda.getSimbolo())
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/RegistroCaeMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/RegistroCaeMapper.java
@@ -1,0 +1,32 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.mapper;
+
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.RegistroCaeResponse;
+import eterea.core.service.model.RegistroCae;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RegistroCaeMapper {
+
+    private final ComprobanteMapper comprobanteMapper;
+
+    public RegistroCaeResponse toResponse(RegistroCae registroCae) {
+        if (registroCae == null) {
+            return null;
+        }
+        return RegistroCaeResponse.builder()
+                .tipoDocumento(registroCae.getTipoDocumento())
+                .puntoVenta(registroCae.getPuntoVenta())
+                .comprobanteId(registroCae.getComprobanteId())
+                .numeroComprobante(registroCae.getNumeroComprobante())
+                .total(registroCae.getTotal())
+                .numeroDocumento(registroCae.getNumeroDocumento())
+                .cae(registroCae.getCae())
+                .caeVencimiento(registroCae.getCaeVencimiento())
+                .fecha(registroCae.getFecha())
+                .comprobante(comprobanteMapper.toResponse(registroCae.getComprobante()))
+                .build();
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/web/InvoiceDataController.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/web/InvoiceDataController.java
@@ -1,0 +1,26 @@
+package eterea.core.service.hexagonal.invoicedata.infrastructure.web;
+
+import eterea.core.service.hexagonal.invoicedata.application.service.InvoiceDataService;
+import eterea.core.service.hexagonal.invoicedata.infrastructure.dto.InvoiceDataResponse;
+import eterea.core.service.hexagonal.invoicedata.infrastructure.mapper.InvoiceDataMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/core/invoiceData")
+@RequiredArgsConstructor
+public class InvoiceDataController {
+
+    private final InvoiceDataService invoiceDataService;
+    private final InvoiceDataMapper invoiceDataMapper;
+
+    @GetMapping("/{clienteMovimientoId}")
+    public ResponseEntity<InvoiceDataResponse> getInvoiceDatabyClienteMovimientoId(@PathVariable Long clienteMovimientoId) {
+        return ResponseEntity.ok(invoiceDataMapper.toResponse(invoiceDataService.getInvoiceData(clienteMovimientoId)));
+    }
+}

--- a/src/main/java/eterea/core/service/model/ClienteMovimiento.java
+++ b/src/main/java/eterea/core/service/model/ClienteMovimiento.java
@@ -1,6 +1,7 @@
 package eterea.core.service.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import eterea.core.service.hexagonal.empresa.infrastructure.persistence.entity.EmpresaEntity;
 import eterea.core.service.kotlin.model.Cliente;
 import eterea.core.service.kotlin.model.Comprobante;
 import eterea.core.service.kotlin.model.Moneda;
@@ -11,13 +12,14 @@ import lombok.*;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
+@Getter
+@Setter
 @Entity
 @Table(name = "movclie")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class ClienteMovimiento extends Auditable {
 
     @Id
@@ -182,6 +184,10 @@ public class ClienteMovimiento extends Auditable {
     @OneToOne(optional = true)
     @JoinColumn(name = "mcl_mon_id", insertable = false, updatable = false)
     private Moneda moneda;
+
+    @OneToOne(optional = true)
+    @JoinColumn(name = "mcl_emp_id",  insertable = false, updatable = false)
+    private EmpresaEntity empresa;
 
     public String jsonify() {
         return Jsonifier.builder(this).build();

--- a/src/main/java/eterea/core/service/model/RegistroCae.java
+++ b/src/main/java/eterea/core/service/model/RegistroCae.java
@@ -1,5 +1,6 @@
 package eterea.core.service.model;
 
+import eterea.core.service.kotlin.model.Comprobante;
 import eterea.core.service.tool.Jsonifier;
 import jakarta.persistence.*;
 import lombok.*;
@@ -86,6 +87,10 @@ public class RegistroCae extends Auditable {
 
     private Long clienteMovimientoIdAsociado;
     private String trackUuid;
+
+    @OneToOne(optional = true)
+    @JoinColumn(name = "rec_tco_id", insertable = false, updatable = false)
+    private Comprobante comprobante;
 
     public String jsonify() {
         return Jsonifier.builder(this).build();

--- a/src/main/java/eterea/core/service/service/facade/StockService.java
+++ b/src/main/java/eterea/core/service/service/facade/StockService.java
@@ -14,6 +14,7 @@ import eterea.core.service.service.view.SaldoArticuloService;
 import eterea.core.service.service.view.SaldoFechaService;
 import eterea.core.service.tool.Jsonifier;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class StockService {
 
     private final StockMovimientoService stockMovimientoService;
@@ -33,20 +35,6 @@ public class StockService {
     private final SaldoArticuloService saldoArticuloService;
     private final ArticuloSaldoFechaService articuloSaldoFechaService;
     private final ArticuloCentroService articuloCentroService;
-
-    public StockService(StockMovimientoService stockMovimientoService,
-                        ArticuloMovimientoService articuloMovimientoService,
-                        SaldoFechaService saldoFechaService,
-                        SaldoArticuloService saldoArticuloService,
-                        ArticuloSaldoFechaService articuloSaldoFechaService,
-                        ArticuloCentroService articuloCentroService) {
-        this.stockMovimientoService = stockMovimientoService;
-        this.articuloMovimientoService = articuloMovimientoService;
-        this.saldoFechaService = saldoFechaService;
-        this.saldoArticuloService = saldoArticuloService;
-        this.articuloSaldoFechaService = articuloSaldoFechaService;
-        this.articuloCentroService = articuloCentroService;
-    }
 
     @Transactional
     public StockMovimiento addMovimiento(StockAndArticulosDto stockAndArticulos) {


### PR DESCRIPTION
## Descripción

Esta PR implementa la versión 2.1.0 del servicio core, incluyendo un nuevo módulo hexagonal `InvoiceData` para consulta de datos de facturación completa, actualización de dependencias y mejoras en la documentación.

Resuelve la issue #168 - Release v2.1.0

## Cambios Realizados

- [x] **Nuevo módulo hexagonal `InvoiceData`**: Implementación completa de arquitectura hexagonal para consulta de datos de facturación
  - Nuevo endpoint `GET /api/core/invoiceData/{clienteMovimientoId}` para obtener datos completos de factura
  - Modelo de dominio `InvoiceData` con información de cliente, movimiento, CAE y comprobante asociado
  - Estructura completa: domain/, application/, infrastructure/
  - Mappers para transformación de entidades: `InvoiceDataMapper`, `ClienteMovimientoMapper`, `RegistroCaeMapper`, `ArticuloMovimientoMapper`, `ClienteMapper`, `EmpresaMapper`, `ComprobanteMapper`, `ComprobanteAfipMapper`, `MonedaMapper`, `ConceptoFacturadoMapper`
  - DTOs de respuesta estructurados: `InvoiceDataResponse`, `ClienteMovimientoResponse`, `RegistroCaeResponse`, etc.
- [x] **Refactor en `StockService`**: Simplificación de inyección de dependencias usando `@RequiredArgsConstructor`
- [x] **Refactor en `EmpresaMapper`**: Adición de método `toResponse()` para soporte de DTOs
- [x] **Actualización de modelos**: Nuevas relaciones JPA en `ClienteMovimiento` y `RegistroCae`
- [x] **Actualización de dependencias**: Spring Boot 4.0.1 → 4.0.2
- [x] **Documentación**: Actualización de `README.md`, `CHANGELOG.md` y workflow `generate-docs.yml`

## Impacto Potencial

- [ ] Los cambios mantienen compatibilidad hacia atrás con la API existente
- [ ] Se actualizan relaciones JPA en modelos existentes (`ClienteMovimiento`, `RegistroCae`) para soportar consultas enriquecidas
- [ ] No se requieren migraciones de base de datos (cambios solo en relaciones JPA)
- [ ] La arquitectura hexagonal sigue el patrón establecido en el proyecto (módulos Legajo, Empresa, etc.)

## Verificación

Pasos para probar los cambios localmente:

1. `git checkout 168-release-v210---new-invoicedata-hexagonal-module-and-spring-boot-402-update`
2. `mvn clean install`
3. `mvn spring-boot:run`
4. Probar el nuevo endpoint:
   ```bash
   curl http://localhost:8080/api/core/invoiceData/{clienteMovimientoId}
   ```
5. Verificar que la aplicación inicia correctamente sin errores de contexto Spring
6. Ejecutar tests: `mvn test`

## Notas Adicionales

- Este cambio mantiene la consistencia con la arquitectura hexagonal establecida en el proyecto
- Se incluye diagrama de clases Mermaid para el nuevo módulo (`invoicedata-class-diagram.mmd`)
- La versión del proyecto se actualiza a 2.1.0 en `pom.xml`
- Issue relacionada: Closes #168
