### PR TITLE
refactor(facturacion-exportacion): usar BigDecimal para cantidades decimales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.1.1] - 2026-02-27
+
+### Changed
+- **refactor(facturacion-exportacion)**: Cambio del tipo de dato `cantidad` de `Integer` a `BigDecimal` en `FacturaExportacionFacturadorItem` para permitir cantidades decimales en facturación de exportación
+- **refactor(facturacion-exportacion)**: Ajuste en `FacturaElectronicaExportacionService` para usar `BigDecimal` directamente sin conversión a `int`
+- **refactor(service)**: Simplificación de inyección de dependencias en `ArticuloMovimientoTemporalService` usando `@RequiredArgsConstructor`
+
 ## [2.1.0] - 2026-01-31
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.1-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.5.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.1.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.1.1-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.1</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/hexagonal/facturacion/arca/exportacion/application/ports/out/FacturaExportacionFacturadorItem.java
+++ b/src/main/java/eterea/core/service/hexagonal/facturacion/arca/exportacion/application/ports/out/FacturaExportacionFacturadorItem.java
@@ -18,7 +18,7 @@ public class FacturaExportacionFacturadorItem {
     private String descripcion;
 
     @JsonProperty(value = "pro_qty")
-    private Integer cantidad;
+    private BigDecimal cantidad;
 
     @JsonProperty(value = "pro_umed")
     private Integer unidadMedida;

--- a/src/main/java/eterea/core/service/hexagonal/facturacion/arca/exportacion/application/service/FacturaElectronicaExportacionService.java
+++ b/src/main/java/eterea/core/service/hexagonal/facturacion/arca/exportacion/application/service/FacturaElectronicaExportacionService.java
@@ -42,7 +42,7 @@ public class FacturaElectronicaExportacionService {
                 .map(movimiento -> new FacturaExportacionFacturadorItem(
                         movimiento.getArticuloId(),
                         movimiento.getDescripcion(),
-                        movimiento.getCantidad().abs().intValue(),
+                        movimiento.getCantidad().abs(),
                         7,
                         movimiento.getPrecioUnitario(),
                         movimiento.getTotal()))

--- a/src/main/java/eterea/core/service/service/ArticuloMovimientoTemporalService.java
+++ b/src/main/java/eterea/core/service/service/ArticuloMovimientoTemporalService.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import eterea.core.service.kotlin.model.ArticuloMovimientoTemporal;
 import eterea.core.service.repository.ArticuloMovimientoTemporalRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -15,13 +16,10 @@ import org.springframework.stereotype.Service;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class ArticuloMovimientoTemporalService {
 
 	private final ArticuloMovimientoTemporalRepository repository;
-
-	public ArticuloMovimientoTemporalService(ArticuloMovimientoTemporalRepository repository) {
-		this.repository = repository;
-	}
 
 	public List<ArticuloMovimientoTemporal> findAllByHWnd(String ipAddress, Long hWnd, Integer centroId) {
 		Sort sort = Sort.by("item").ascending()


### PR DESCRIPTION
Closes #170

## Descripción

Se realiza refactorización del módulo de facturación-exportación para permitir cantidades decimales, cambiando el tipo de dato de `cantidad` de `Integer` a `BigDecimal`. También se simplifica la inyección de dependencias en `ArticuloMovimientoTemporalService` usando `@RequiredArgsConstructor` de Lombok.

## Cambios Realizados

- **FacturaExportacionFacturadorItem.java**: Cambio del tipo de dato `cantidad` de `Integer` a `BigDecimal` para permitir cantidades decimales en facturación de exportación
- **FacturaElectronicaExportacionService.java**: Ajuste para usar `BigDecimal` directamente sin conversión a `int`
- **ArticuloMovimientoTemporalService.java**: Simplificación de inyección de dependencias usando `@RequiredArgsConstructor` de Lombok
- **CHANGELOG.md**: Agregada entrada para versión 2.1.1
- **README.md**: Actualización del badge de versión
- **pom.xml**: Actualización de versión de 2.0.0 a 2.1.1

## Verificación

- Compilación exitosa con `mvn clean install`
- Ejecución de tests unitarios
- Revisión de código por pares
