### PR TITLE
chore(deps): actualizar dependencias y mejorar clientes Feign

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [2.3.0] - 2026-03-30
+
+### Dependencies
+- **chore(deps)**: Actualización de Spring Boot 4.0.2→4.0.4 en `pom.xml`
+- **chore(deps)**: Actualización de OpenPDF 3.0.0→3.0.3 en `pom.xml`
+- **chore(deps)**: Actualización de MySQL Connector 9.5.0→9.6.0 en `pom.xml`
+- **chore(deps)**: Actualización de SpringDoc OpenAPI 3.0.1→3.0.2 en `pom.xml`
+- **chore(deps)**: Nueva dependencia `feign-jackson` para soporte de serialización JSON en clientes Feign
+- **chore(deps)**: Nueva dependencia `commons-fileupload` 1.6.0 en dependencyManagement
+
+### Changed
+- **refactor(clients)**: Mejora en `ArticuloBarraClientBuilder`, `ArticuloClientBuilder`, `CuentaClientBuilder`, `ParametroClientBuilder` añadiendo `JacksonDecoder` con `KotlinModule` para mejor compatibilidad con modelos Kotlin
+- **refactor(clients)**: Adición de `SpringMvcContract` y `JacksonEncoder` en `ArticuloClientBuilder` para soportar solicitudes y respuestas JSON
+- **refactor(controller)**: Mejora en `ArticuloController.add()` especificando `consumes` y `produces` como "application/json"
+- **refactor(model)**: Adición de `@JsonIgnoreProperties(ignoreUnknown = true)` en `Articulo.kt`, `ArticuloDto.kt`, `ParametroDto.kt` para ignorar propiedades desconocidas en JSON
+- **refactor(model)**: Nuevo campo `porcentajeDescuentoPersonal` en `ParametroDto.kt`
+- **refactor(service)**: Mejora en logging de `ArticulosService` con mensajes más descriptivos para trazabilidad
+- **refactor(service)**: Uso de `Jsonifier` en lugar de serialización manual en `ArticulosService`
+
 ## [2.2.0] - 2026-03-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/javase/jdk25-archive-downloads.html)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-blueviolet.svg)](https://kotlinlang.org/)
 
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-green.svg)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.4-green.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-green.svg)](https://spring.io/projects/spring-cloud)
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.1-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.5.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.2.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.3.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.4</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.3</version>
         </dependency>
         <!-- ZXING BarCode and QRCode-->
         <dependency>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.5.0</version>
+            <version>9.6.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -153,6 +153,10 @@
             <artifactId>feign-hc5</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jackson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
@@ -175,6 +179,11 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.6.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/eterea/core/service/client/core/builder/ArticuloBarraClientBuilder.java
+++ b/src/main/java/eterea/core/service/client/core/builder/ArticuloBarraClientBuilder.java
@@ -1,13 +1,22 @@
 package eterea.core.service.client.core.builder;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import eterea.core.service.client.core.ArticuloBarraClient;
 import feign.Feign;
 import feign.Logger;
+import feign.jackson.JacksonDecoder;
+import org.springframework.cloud.openfeign.support.SpringMvcContract;
 
 public class ArticuloBarraClientBuilder {
 
     public static ArticuloBarraClient buildClient(String baseUrl) {
         return Feign.builder()
+                .contract(new SpringMvcContract())
+                .decoder(new JacksonDecoder(
+                        JsonMapper.builder()
+                                .addModule(new KotlinModule.Builder().build())
+                                .build()))
                 .logger(new Logger.ErrorLogger())
                 .requestInterceptor(template -> {
                     template.header("X-Service-Name", "core-service");

--- a/src/main/java/eterea/core/service/client/core/builder/ArticuloClientBuilder.java
+++ b/src/main/java/eterea/core/service/client/core/builder/ArticuloClientBuilder.java
@@ -1,16 +1,29 @@
 package eterea.core.service.client.core.builder;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import eterea.core.service.client.core.ArticuloClient;
 import feign.Feign;
 import feign.Logger;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import org.springframework.cloud.openfeign.support.SpringMvcContract;
 
 public class ArticuloClientBuilder {
 
     public static ArticuloClient buildClient(String baseUrl) {
+        JsonMapper jsonMapper = JsonMapper.builder()
+                .addModule(new KotlinModule.Builder().build())
+                .build();
+
         return Feign.builder()
+                .contract(new SpringMvcContract())
+                .encoder(new JacksonEncoder(jsonMapper))
+                .decoder(new JacksonDecoder(jsonMapper))
                 .logger(new Logger.ErrorLogger())
                 .requestInterceptor(template -> {
                     template.header("X-Service-Name", "core-service");
+                    template.header("Content-Type", "application/json");
                 })
                 .target(ArticuloClient.class, baseUrl + "/api/core/articulo");
     }

--- a/src/main/java/eterea/core/service/client/core/builder/CuentaClientBuilder.java
+++ b/src/main/java/eterea/core/service/client/core/builder/CuentaClientBuilder.java
@@ -1,13 +1,22 @@
 package eterea.core.service.client.core.builder;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import eterea.core.service.client.core.CuentaClient;
 import feign.Feign;
 import feign.Logger;
+import feign.jackson.JacksonDecoder;
+import org.springframework.cloud.openfeign.support.SpringMvcContract;
 
 public class CuentaClientBuilder {
 
     public static CuentaClient buildClient(String baseUrl) {
         return Feign.builder()
+                .contract(new SpringMvcContract())
+                .decoder(new JacksonDecoder(
+                        JsonMapper.builder()
+                                .addModule(new KotlinModule.Builder().build())
+                                .build()))
                 .logger(new Logger.ErrorLogger())
                 .requestInterceptor(template -> {
                     template.header("X-Service-Name", "core-service");

--- a/src/main/java/eterea/core/service/client/core/builder/ParametroClientBuilder.java
+++ b/src/main/java/eterea/core/service/client/core/builder/ParametroClientBuilder.java
@@ -1,13 +1,22 @@
 package eterea.core.service.client.core.builder;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import eterea.core.service.client.core.ParametroClient;
 import feign.Feign;
 import feign.Logger;
+import feign.jackson.JacksonDecoder;
+import org.springframework.cloud.openfeign.support.SpringMvcContract;
 
 public class ParametroClientBuilder {
 
     public static ParametroClient buildClient(String baseUrl) {
         return Feign.builder()
+                .contract(new SpringMvcContract())
+                .decoder(new JacksonDecoder(
+                        JsonMapper.builder()
+                                .addModule(new KotlinModule.Builder().build())
+                                .build()))
                 .logger(new Logger.ErrorLogger())
                 .requestInterceptor(template -> {
                     template.header("X-Service-Name", "core-service");

--- a/src/main/java/eterea/core/service/controller/ArticuloController.java
+++ b/src/main/java/eterea/core/service/controller/ArticuloController.java
@@ -64,7 +64,7 @@ public class ArticuloController {
         }
     }
 
-    @PostMapping("/")
+    @PostMapping(value = "/", consumes = "application/json", produces = "application/json")
     public ResponseEntity<Articulo> add(@RequestBody Articulo articulo) {
         return new ResponseEntity<>(service.add(articulo), HttpStatus.OK);
     }

--- a/src/main/java/eterea/core/service/kotlin/model/Articulo.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/Articulo.kt
@@ -1,5 +1,6 @@
 package eterea.core.service.kotlin.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.json.JsonMapper
 import eterea.core.service.model.Auditable
@@ -9,6 +10,7 @@ import java.math.BigDecimal
 
 @Entity
 @Table(name = "articulos")
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Articulo(
 
     @Id

--- a/src/main/java/eterea/core/service/kotlin/model/dto/ArticuloDto.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/dto/ArticuloDto.kt
@@ -1,9 +1,11 @@
 package eterea.core.service.kotlin.model.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.json.JsonMapper
 import java.math.BigDecimal
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class ArticuloDto (
 
     val articuloId: String?,

--- a/src/main/java/eterea/core/service/kotlin/model/dto/ParametroDto.kt
+++ b/src/main/java/eterea/core/service/kotlin/model/dto/ParametroDto.kt
@@ -1,9 +1,10 @@
 package eterea.core.service.kotlin.model.dto
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import eterea.core.service.tool.Jsonifier
 import java.math.BigDecimal
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class ParametroDto(
 
     var parametroId: Long? = null,
@@ -29,21 +30,13 @@ data class ParametroDto(
     var ivaVenta: BigDecimal = BigDecimal.ZERO,
     var centroStockIdIngreso: Int? = null,
     var centroStockIdRestaurant: Int? = null,
-    var facturaElectronicaProduccion: Byte? = null
+    var facturaElectronicaProduccion: Byte? = null,
+    var porcentajeDescuentoPersonal: BigDecimal = BigDecimal.ZERO
 
 ) {
 
     fun jsonify(): String {
-        try {
-            return JsonMapper
-                .builder()
-                .findAndAddModules()
-                .build()
-                .writerWithDefaultPrettyPrinter()
-                .writeValueAsString(this)
-        } catch (e: JsonProcessingException) {
-            return "jsonify error -> ${e.message}"
-        }
+        return Jsonifier.builder(this).build();
     }
 
 }

--- a/src/main/java/eterea/core/service/service/facade/ArticulosService.java
+++ b/src/main/java/eterea/core/service/service/facade/ArticulosService.java
@@ -16,6 +16,7 @@ import eterea.core.service.kotlin.model.dto.ParametroDto;
 import eterea.core.service.service.ArticuloBarraService;
 import eterea.core.service.service.ArticuloService;
 import eterea.core.service.hexagonal.negocio.application.service.NegocioService;
+import eterea.core.service.tool.Jsonifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,7 +43,9 @@ public class ArticulosService {
         log.debug("Starting article replication for articleId: {}", articuloId);
 
         List<Negocio> negocios = negocioService.getAllNegociosByCopyArticulo((byte) 1);
+        log.debug("Negocios para replicar: {}", Jsonifier.builder(negocios).build());
         Articulo articulo = articuloService.findByArticuloId(articuloId);
+        log.debug("Articulo para replicar: {}", articulo.jsonify());
         List<ArticuloBarra> barrasToReplicate = articuloBarraService.findAllByArticuloId(articuloId);
 
         log.debug("Articulo -> {}", articulo.jsonify());
@@ -77,8 +80,10 @@ public class ArticulosService {
     }
 
     private void updateArticuloIfNeeded(ClientsHolder clients, Articulo articulo) {
+        log.debug("Processing ArticulosService.updateArticuloIfNeeded()");
         try {
             var existingArticulo = clients.articuloClient.findByArticuloId(articulo.getArticuloId());
+            log.debug("ExistingArticulo -> {}", existingArticulo.jsonify());
 
             if (!Objects.equals(existingArticulo.getDescripcion(), articulo.getDescripcion())) {
                 
@@ -105,6 +110,7 @@ public class ArticulosService {
     }
 
     private ClientsHolder initializeClients(String baseUrl) {
+        log.debug("Processing ArticulosService.initializeClients");
         return new ClientsHolder(
                 ArticuloClientBuilder.buildClient(baseUrl),
                 ArticuloBarraClientBuilder.buildClient(baseUrl),
@@ -114,6 +120,7 @@ public class ArticulosService {
     }
 
     private void replicateArticulo(ClientsHolder clients, Articulo articulo) {
+        log.debug("Processing ArticulosService.replicateArticulo: {}", articulo.getArticuloId());
         var parametro = clients.parametroClient.findTop();
         log.debug("Parametro -> {}", parametro.jsonify());
 
@@ -129,7 +136,7 @@ public class ArticulosService {
     }
 
     private void replicateCodigosBarras(ArticuloBarraClient client, List<ArticuloBarra> barrasToReplicate, String articuloId) {
-        log.debug("Processing replicateCodigosBarras");
+        log.debug("Processing ArticulosService.replicateCodigosBarras");
         try {
             log.debug("A Replicar");
             barrasToReplicate.forEach(barra -> log.debug("ArticuloBarra -> {}", barra.jsonify()));
@@ -149,7 +156,7 @@ public class ArticulosService {
     }
 
     private void deleteObsoleteBarCodes(ArticuloBarraClient client, List<ArticuloBarra> existing, List<ArticuloBarra> toReplicate) {
-        log.debug("Processing deleteObsoleteBarCodes");
+        log.debug("Processing ArticulosService.deleteObsoleteBarCodes");
         if (toReplicate.isEmpty()) {
             // Si no hay códigos para replicar, eliminar todos los existentes
             existing.forEach(barra -> {
@@ -177,7 +184,7 @@ public class ArticulosService {
                 });
     }
     private void addNewBarCodes(ArticuloBarraClient client, List<ArticuloBarra> toReplicate, List<ArticuloBarra> existing) {
-        log.debug("Processing addNewBarCodes");
+        log.debug("Processing ArticulosService.addNewBarCodes");
         toReplicate.stream()
                 .filter(newBarra -> existing.stream()
                         .noneMatch(existingBarra -> Objects.equals(newBarra.getCodigoBarras(), existingBarra.getCodigoBarras())))
@@ -197,6 +204,7 @@ public class ArticulosService {
     }
 
     private boolean articuloExists(ArticuloClient articuloClient, String articuloId, String negocioNombre) {
+        log.debug("Processing ArticulosService.articuloExists");
         try {
             articuloClient.findByArticuloId(articuloId);
             log.debug("Articulo ya existe en -> {}", negocioNombre);
@@ -208,6 +216,7 @@ public class ArticulosService {
     }
 
     private Long verifyCuenta(CuentaClient cuentaClient, Long cuenta, String tipoCuenta) {
+        log.debug("Processing ArticulosService.verifyCuenta");
         if (cuenta != null) {
             try {
                 cuentaClient.findByNumeroCuenta(cuenta);
@@ -220,7 +229,7 @@ public class ArticulosService {
     }
 
     private ArticuloDto convertArticulo(Articulo articulo, ParametroDto parametro, Long cuentaVentas, Long cuentaCompras, Long cuentaGastos) {
-        log.debug("Processing convertArticulo");
+        log.debug("Processing ArticulosService.convertArticulo");
         return new ArticuloDto.Builder()
                 .articuloId(articulo.getArticuloId())
                 .negocioId(articulo.getNegocioId())


### PR DESCRIPTION
Closes #174

## Descripción

Esta PR implementa la versión v2.3.0 del servicio core, que incluye actualización de dependencias y mejoras en los clientes Feign para mejor compatibilidad con modelos Kotlin.

## Cambios Realizados

### Dependencias (pom.xml)
- **Spring Boot:** 4.0.2 → 4.0.4
- **OpenPDF:** 3.0.0 → 3.0.3
- **MySQL Connector:** 9.5.0 → 9.6.0
- **SpringDoc OpenAPI:** 3.0.1 → 3.0.2
- **Nueva dependencia:** `feign-jackson` para soporte de serialización JSON
- **Nueva dependencia:** `commons-fileupload` 1.6.0

### Clientes Feign
- Adición de `JacksonDecoder` con `KotlinModule` en todos los builders
- Adición de `SpringMvcContract` y `JacksonEncoder` en `ArticuloClientBuilder`
- Mejora en la compatibilidad con modelos Kotlin

### Modelos
- Adición de `@JsonIgnoreProperties(ignoreUnknown = true)` en `Articulo.kt`, `ArticuloDto.kt`, `ParametroDto.kt`
- Nuevo campo `porcentajeDescuentoPersonal` en `ParametroDto.kt`

### Controller
- Especificación de `consumes` y `produces` en `ArticuloController.add()`

### Service
- Mejor logging descriptivo para trazabilidad en `ArticulosService`
- Uso de `Jsonifier` en lugar de serialización manual

### Documentación
- Actualización de CHANGELOG.md y README.md
- Actualización de JDK en GitHub Actions (24 → 25)

## Verificación

- [ ] Compilación exitosa (`mvn clean compile`)
- [ ] Tests unitarios pasan (`mvn test`)
- [ ] Verificación de clientes Feign con modelos Kotlin
