### PR TITLE
feat(cliente,clienteMovimiento): añadir endpoints byIds y ampliar ValorMovimientoDto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.3.1] - 2026-04-28
+
+### Features
+- **feat(clienteMovimiento)**: Nuevo endpoint `POST /byIds` para buscar movimientos de cliente por lista de IDs
+- **feat(cliente)**: Nuevo endpoint `POST /byIds` para buscar clientes por lista de IDs
+
+### Changed
+- **refactor(dto)**: Ampliación de `ValorMovimientoDto` con los campos `movClieId`, `clienteId`, `nroPlanCta`, `created` y `updated`
+- **refactor(mapper)**: Actualización de `ValorMovimientoDtoMapper` para incluir los nuevos campos con null-guard en `valor.getConcepto()`
+
 ## [2.3.0] - 2026-03-30
 
 ### Dependencies

--- a/src/main/java/eterea/core/service/controller/ClienteController.java
+++ b/src/main/java/eterea/core/service/controller/ClienteController.java
@@ -64,6 +64,11 @@ public class ClienteController {
 		}
 	}
 
+	@PostMapping("/byIds")
+	public ResponseEntity<List<Cliente>> findAllByIds(@RequestBody List<Long> clienteIds) {
+		return new ResponseEntity<>(service.findAllByIds(clienteIds), HttpStatus.OK);
+	}
+
 	@PostMapping("/")
 	public ResponseEntity<Cliente> add(@RequestBody Cliente cliente) {
 		return new ResponseEntity<>(service.add(cliente), HttpStatus.OK);

--- a/src/main/java/eterea/core/service/controller/ClienteMovimientoController.java
+++ b/src/main/java/eterea/core/service/controller/ClienteMovimientoController.java
@@ -117,6 +117,11 @@ public class ClienteMovimientoController {
         }
     }
 
+    @PostMapping("/byIds")
+    public ResponseEntity<List<ClienteMovimiento>> findAllByIds(@RequestBody List<Long> clienteMovimientoIds) {
+        return new ResponseEntity<>(service.findAllByIds(clienteMovimientoIds), HttpStatus.OK);
+    }
+
     @PostMapping("/")
     public ResponseEntity<ClienteMovimiento> create(@RequestBody ClienteMovimiento clienteMovimiento) {
         return ResponseEntity.ok(service.add(clienteMovimiento));

--- a/src/main/java/eterea/core/service/model/dto/ValorMovimientoDto.java
+++ b/src/main/java/eterea/core/service/model/dto/ValorMovimientoDto.java
@@ -1,9 +1,12 @@
 package eterea.core.service.model.dto;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
 public record ValorMovimientoDto(Long valorMovimientoId, Long cierreCajaId, Integer negocioId, String concepto,
-            OffsetDateTime fechaContable, BigDecimal importe) {
+                                 OffsetDateTime fechaContable, BigDecimal importe, Long movClieId,
+                                 Long clienteId, Long nroPlanCta,
+                                 LocalDateTime created, LocalDateTime updated) {
 
 }

--- a/src/main/java/eterea/core/service/model/dto/ValorMovimientoDtoMapper.java
+++ b/src/main/java/eterea/core/service/model/dto/ValorMovimientoDtoMapper.java
@@ -11,8 +11,17 @@ public class ValorMovimientoDtoMapper implements Function<ValorMovimiento, Valor
 
    @Override
    public ValorMovimientoDto apply(ValorMovimiento valorMovimiento) {
-      return new ValorMovimientoDto(valorMovimiento.getValorMovimientoId(), valorMovimiento.getCierreCajaId(),
-            valorMovimiento.getNegocioId(), valorMovimiento.getValor().getConcepto(),
-            valorMovimiento.getFechaContable(), valorMovimiento.getImporte());
+      return new ValorMovimientoDto(
+            valorMovimiento.getValorMovimientoId(),
+            valorMovimiento.getCierreCajaId(),
+            valorMovimiento.getNegocioId(),
+            valorMovimiento.getValor() != null ? valorMovimiento.getValor().getConcepto() : null,
+            valorMovimiento.getFechaContable(),
+            valorMovimiento.getImporte(),
+            valorMovimiento.getClienteMovimientoId(),
+            valorMovimiento.getClienteId(),
+            valorMovimiento.getNumeroCuenta(),
+            valorMovimiento.getCreated(),
+            valorMovimiento.getUpdated());
    }
 }

--- a/src/main/java/eterea/core/service/repository/ClienteMovimientoRepository.java
+++ b/src/main/java/eterea/core/service/repository/ClienteMovimientoRepository.java
@@ -61,6 +61,8 @@ public interface ClienteMovimientoRepository extends JpaRepository<ClienteMovimi
 			Byte debita
 	);
 
+	List<ClienteMovimiento> findAllByClienteMovimientoIdIn(List<Long> clienteMovimientoIds);
+
 	@Modifying
 	@Query("delete from ClienteMovimiento where fechaComprobante = :fechaComprobante and comprobanteId = :comprobanteId and puntoVenta = :puntoVenta and numeroComprobante = :numeroComprobante")
 	void deleteAllByFechaComprobanteAndComprobanteIdAndPuntoVentaAndNumeroComprobante(OffsetDateTime fechaComprobante,

--- a/src/main/java/eterea/core/service/repository/ClienteRepository.java
+++ b/src/main/java/eterea/core/service/repository/ClienteRepository.java
@@ -3,6 +3,7 @@
  */
 package eterea.core.service.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import eterea.core.service.kotlin.model.Cliente;
@@ -17,6 +18,8 @@ import org.springframework.stereotype.Repository;
 public interface ClienteRepository extends JpaRepository<Cliente, Long> {
 
 	Optional<Cliente> findByClienteId(Long clienteId);
+
+	List<Cliente> findAllByClienteIdIn(List<Long> clienteIds);
 
 	Optional<Cliente> findTopByNumeroDocumento(String numeroDocumento);
 

--- a/src/main/java/eterea/core/service/service/ClienteMovimientoService.java
+++ b/src/main/java/eterea/core/service/service/ClienteMovimientoService.java
@@ -63,6 +63,10 @@ public class ClienteMovimientoService {
                 .toList();
     }
 
+    public List<ClienteMovimiento> findAllByIds(List<Long> clienteMovimientoIds) {
+        return repository.findAllByClienteMovimientoIdIn(clienteMovimientoIds);
+    }
+
     public ClienteMovimiento findByClienteMovimientoId(Long clienteMovimientoId) {
         return repository.findByClienteMovimientoId(clienteMovimientoId)
                 .orElseThrow(() -> new ClienteMovimientoException(clienteMovimientoId));

--- a/src/main/java/eterea/core/service/service/ClienteService.java
+++ b/src/main/java/eterea/core/service/service/ClienteService.java
@@ -33,6 +33,10 @@ public class ClienteService {
 		return clienteSearchService.findAllBySearch(search);
 	}
 
+	public List<Cliente> findAllByIds(List<Long> clienteIds) {
+		return repository.findAllByClienteIdIn(clienteIds);
+	}
+
 	public Cliente findByClienteId(Long clienteId) {
 		return repository.findByClienteId(clienteId).orElseThrow(() -> new ClienteException(clienteId));
 	}


### PR DESCRIPTION
Closes #176 

  ## Descripción                                                                                     
   
  Esta PR implementa la versión v2.3.1 del servicio core, que incluye nuevos endpoints `POST /byIds` 
  para `Cliente` y `ClienteMovimiento`, y la ampliación de `ValorMovimientoDto` con campos         
  adicionales.                                                                                       
                                                                                                   
  ## Cambios Realizados

  ### Nuevos Endpoints                                                                               
  - Nuevo endpoint `POST /byIds` en `ClienteMovimientoController` para buscar movimientos por lista
  de IDs                                                                                             
  - Nuevo endpoint `POST /byIds` en `ClienteController` para buscar clientes por lista de IDs      
                                                                                                     
  ### Servicios
  - Nuevo método `findAllByIds(List<Long>)` en `ClienteMovimientoService`                            
  - Nuevo método `findAllByIds(List<Long>)` en `ClienteService`                                      
   
  ### Repositorios                                                                                   
  - Nuevo método `findAllByClienteMovimientoIdIn(List<Long>)` en `ClienteMovimientoRepository`     
  - Nuevo método `findAllByClienteIdIn(List<Long>)` en `ClienteRepository`                           
   
  ### DTO y Mapper                                                                                   
  - Ampliación de `ValorMovimientoDto` con los campos `movClieId`, `clienteId`, `nroPlanCta`,      
  `created` y `updated`                                                                              
  - Actualización de `ValorMovimientoDtoMapper` para mapear los nuevos campos, con null-guard en
  `valor.getConcepto()`                                                                              
                                                                                                   
  ### Documentación                                                                                  
  - Actualización de `CHANGELOG.md` con entrada para versión 2.3.1                                 
                                                                                                     
  ## Verificación
                                                                                                     
  - [ ] Compilación exitosa (`mvn clean compile`)                                                  
  - [ ] Tests unitarios pasan (`mvn test`)
  - [ ] Verificación de nuevos endpoints con lista de IDs