### PR TITLE
refactor(empresa): extract use case from service, rename repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,21 @@
-<<<<<<< Updated upstream
-## [2.3.1] - 2026-04-28
-
-### Features
-- **feat(clienteMovimiento)**: Nuevo endpoint `POST /byIds` para buscar movimientos de cliente por lista de IDs
-- **feat(cliente)**: Nuevo endpoint `POST /byIds` para buscar clientes por lista de IDs
+## [2.3.1] - 2026-05-30
 
 ### Changed
-- **refactor(dto)**: Ampliación de `ValorMovimientoDto` con los campos `movClieId`, `clienteId`, `nroPlanCta`, `created` y `updated`
-- **refactor(mapper)**: Actualización de `ValorMovimientoDtoMapper` para incluir los nuevos campos con null-guard en `valor.getConcepto()`
+- **refactor(empresa)**: Refactorización completa del módulo `Empresa` para separar correctamente los casos de uso de la capa de servicio en arquitectura hexagonal
+- **refactor(empresa)**: Extracción de `GetLastEmpresaUseCaseImpl` con la lógica de generación de UUID y persistencia desde `EmpresaService`
+- **refactor(empresa)**: Renombrado de `EmpresaJpaRepository` → `JpaEmpresaRepository` y `EmpresaJpaRepositoryAdapter` → `JpaEmpresaRepositoryAdapter` para consistencia con el resto de módulos hexagonales
+- **refactor(empresa)**: Simplificación de `EmpresaService` para que actúe como orquestador delegando en `GetLastEmpresaUseCase`
+- **refactor(empresa)**: `EmpresaController` ahora inyecta `EmpresaService` en lugar de `GetLastEmpresaUseCase` directamente
+- **test(empresa)**: Nuevos tests unitarios completos para `GetLastEmpresaUseCaseImpl` (3 casos: con businessId, sin businessId genera UUID, empresa no encontrada)
+- **test(empresa)**: Simplificación de `EmpresaServiceTest` para verificar únicamente la delegación al caso de uso
 
 ## [2.3.0] - 2026-03-30
-=======
-## [2.3.0] - 2026-05-27
->>>>>>> Stashed changes
 
 ### 🚀 Migración Masiva a Arquitectura Hexagonal
 
 #### Features
+- **feat(clienteMovimiento)**: Nuevo endpoint `POST /byIds` para buscar movimientos de cliente por lista de IDs
+- **feat(cliente)**: Nuevo endpoint `POST /byIds` para buscar clientes por lista de IDs
 - **feat(hexagonal)**: Nuevos módulos hexagonales completos (puertos, casos de uso, JPA, controladores REST):
   - **`articulo`**: Migración completa del modelo `Articulo` de Kotlin a Java con arquitectura hexagonal. Casos de uso: creación, búsqueda (por ID, autoNumerico, máscara balanza, texto, voucher), cálculo de totales y actualización. Nuevo controlador REST con endpoints CRUD y DTOs (`ArticuloRequest`, `ArticuloResponse`, `ArticuloResponseForInvoiceData`, `TotalArticuloResponse`)
   - **`articulomovimiento`**: Migración completa del modelo `ArticuloMovimiento` de Kotlin a Java con arquitectura hexagonal. Casos de uso: creación, consulta por ID, por clienteMovimientoId, por stockMovimientoId, autocompletado de totales y guardado masivo
@@ -28,6 +27,8 @@
 - **feat(clients)**: Actualización de `ArticuloClient`, `CuentaClient`, `ParametroClient` con nuevos builders compatibles con Spring Boot 4.0.6
 
 ### Changed
+- **refactor(dto)**: Ampliación de `ValorMovimientoDto` con los campos `movClieId`, `clienteId`, `nroPlanCta`, `created` y `updated`
+- **refactor(mapper)**: Actualización de `ValorMovimientoDtoMapper` para incluir los nuevos campos con null-guard en `valor.getConcepto()`
 - **refactor(clients)**: Mejora en `ArticuloBarraClientBuilder`, `ArticuloClientBuilder`, `CuentaClientBuilder`, `ParametroClientBuilder` añadiendo `JacksonDecoder` con `KotlinModule` para mejor compatibilidad con modelos Kotlin
 - **refactor(clients)**: Adición de `SpringMvcContract` y `JacksonEncoder` en `ArticuloClientBuilder` para soportar solicitudes y respuestas JSON
 - **refactor(controller)**: Mejora en `ArticuloController.add()` especificando `consumes` y `produces` como "application/json"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ETEREA.core.api.rest
+# ETEREA.core-service
 
 [![ETEREA.core-service CI](https://github.com/ETEREA-services/ETEREA.core-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.core-service/actions/workflows/maven.yml)
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/javase/jdk25-archive-downloads.html)
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.6.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.3.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.3.1-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/docs/diagrams/mermaid/cliente-class-diagram.mmd
+++ b/docs/diagrams/mermaid/cliente-class-diagram.mmd
@@ -6,6 +6,7 @@ classDiagram
         +findByClienteId(Long): ResponseEntity
         +findByNumeroDocumento(String): ResponseEntity
         +findLast(): ResponseEntity
+        +findAllByIds(List~Long~): ResponseEntity~List~Cliente~~
         +add(Cliente): ResponseEntity
     }
 
@@ -14,26 +15,35 @@ classDiagram
         +findByClienteId(Long): Cliente
         +findByNumeroDocumento(String): Cliente
         +findLast(): Cliente
+        +findAllByIds(List~Long~): List~Cliente~
         +add(Cliente): Cliente
+    }
+
+    class ClienteMovimientoController {
+        +findAllByRegimenInformacionVentas(OffsetDateTime, OffsetDateTime): ResponseEntity~List~ClienteMovimiento~~
+        +findAllByIds(List~Long~): ResponseEntity~List~ClienteMovimiento~~
+        +create(ClienteMovimiento): ResponseEntity~ClienteMovimiento~
     }
 
     class ClienteMovimientoService {
         +findAllByRegimenInformacionVentas(OffsetDateTime, OffsetDateTime): List~ClienteMovimiento~
+        +findAllByIds(List~Long~): List~ClienteMovimiento~
     }
 
     class ClienteRepository {
         +findByClienteId(Long): Optional~Cliente~
         +findTopByNumeroDocumento(String): Optional~Cliente~
         +findTopByOrderByClienteIdDesc(): Optional~Cliente~
+        +findAllByClienteIdIn(List~Long~): List~Cliente~
         +save(Cliente): Cliente
     }
 
     class ClienteMovimientoRepository {
         +findAllByFechaComprobanteBetweenAndComprobanteLibroIva(OffsetDateTime, OffsetDateTime, Byte, Sort): List~ClienteMovimiento~
+        +findAllByClienteMovimientoIdIn(List~Long~): List~ClienteMovimiento~
     }
 
     class Cliente {
-        <<Kotlin Data Class>>
         +clienteId: Long
         +nombre: String
         +cuit: String
@@ -48,6 +58,21 @@ classDiagram
     class PosicionIva {
         +posicionId: Integer
         +nombre: String
+    }
+
+    class ValorMovimientoDto {
+        <<record>>
+        +valorMovimientoId: Long
+        +cierreCajaId: Long
+        +negocioId: Integer
+        +concepto: String
+        +fechaContable: OffsetDateTime
+        +importe: BigDecimal
+        +movClieId: Long
+        +clienteId: Long
+        +nroPlanCta: Long
+        +created: LocalDateTime
+        +updated: LocalDateTime
     }
 
     ClienteController --> ClienteService

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/hexagonal/empresa/application/service/EmpresaService.java
+++ b/src/main/java/eterea/core/service/hexagonal/empresa/application/service/EmpresaService.java
@@ -2,29 +2,19 @@ package eterea.core.service.hexagonal.empresa.application.service;
 
 import eterea.core.service.hexagonal.empresa.domain.model.Empresa;
 import eterea.core.service.hexagonal.empresa.domain.ports.in.GetLastEmpresaUseCase;
-import eterea.core.service.hexagonal.empresa.domain.ports.out.EmpresaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class EmpresaService implements GetLastEmpresaUseCase {
+public class EmpresaService {
 
-    private final EmpresaRepository empresaRepository;
+    private final GetLastEmpresaUseCase getLastEmpresaUseCase;
 
-    @Override
     public Optional<Empresa> findLast() {
-        return empresaRepository.findLast()
-                .map(empresa -> {
-                    if (empresa.getBusinessId() == null) {
-                        empresa.setBusinessId(UUID.randomUUID());
-                        empresaRepository.save(empresa);
-                    }
-                    return empresa;
-                });
+        return getLastEmpresaUseCase.findLast();
     }
 
 }

--- a/src/main/java/eterea/core/service/hexagonal/empresa/application/usecases/GetLastEmpresaUseCaseImpl.java
+++ b/src/main/java/eterea/core/service/hexagonal/empresa/application/usecases/GetLastEmpresaUseCaseImpl.java
@@ -1,0 +1,30 @@
+package eterea.core.service.hexagonal.empresa.application.usecases;
+
+import eterea.core.service.hexagonal.empresa.domain.model.Empresa;
+import eterea.core.service.hexagonal.empresa.domain.ports.in.GetLastEmpresaUseCase;
+import eterea.core.service.hexagonal.empresa.domain.ports.out.EmpresaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class GetLastEmpresaUseCaseImpl implements GetLastEmpresaUseCase {
+
+    private final EmpresaRepository empresaRepository;
+
+    @Override
+    public Optional<Empresa> findLast() {
+        return empresaRepository.findLast()
+                .map(empresa -> {
+                    if (empresa.getBusinessId() == null) {
+                        empresa.setBusinessId(UUID.randomUUID());
+                        empresaRepository.save(empresa);
+                    }
+                    return empresa;
+                });
+    }
+
+}

--- a/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/mapper/EmpresaMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/mapper/EmpresaMapper.java
@@ -60,6 +60,10 @@ public class EmpresaMapper {
                 .build();
     }
 
+    /*
+     * TODO: This method belongs to invoicedata slice or should use a shared DTO.
+     * It is kept here for compatibility with ClienteMovimientoMapper.
+     */
     public EmpresaResponse toResponse(EmpresaEntity empresaEntity) {
         if (empresaEntity == null) {
             return null;

--- a/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/repository/JpaEmpresaRepository.java
+++ b/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/repository/JpaEmpresaRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface EmpresaJpaRepository extends JpaRepository<EmpresaEntity, Integer> {
+public interface JpaEmpresaRepository extends JpaRepository<EmpresaEntity, Integer> {
 
     Optional<EmpresaEntity> findTopByOrderByEmpresaIdDesc();
 

--- a/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/repository/JpaEmpresaRepositoryAdapter.java
+++ b/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/persistence/repository/JpaEmpresaRepositoryAdapter.java
@@ -10,20 +10,20 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class EmpresaJpaRepositoryAdapter implements EmpresaRepository {
+public class JpaEmpresaRepositoryAdapter implements EmpresaRepository {
 
-    private final EmpresaJpaRepository empresaJpaRepository;
+    private final JpaEmpresaRepository jpaEmpresaRepository;
     private final EmpresaMapper empresaMapper;
 
     @Override
     public Optional<Empresa> findLast() {
-        return empresaJpaRepository.findTopByOrderByEmpresaIdDesc()
+        return jpaEmpresaRepository.findTopByOrderByEmpresaIdDesc()
                 .map(empresaMapper::toDomainModel);
     }
 
     @Override
     public void save(Empresa empresa) {
-        empresaJpaRepository.save(empresaMapper.toEntity(empresa));
+        jpaEmpresaRepository.save(empresaMapper.toEntity(empresa));
     }
 
 }

--- a/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/web/controller/EmpresaController.java
+++ b/src/main/java/eterea/core/service/hexagonal/empresa/infrastructure/web/controller/EmpresaController.java
@@ -1,6 +1,6 @@
 package eterea.core.service.hexagonal.empresa.infrastructure.web.controller;
 
-import eterea.core.service.hexagonal.empresa.domain.ports.in.GetLastEmpresaUseCase;
+import eterea.core.service.hexagonal.empresa.application.service.EmpresaService;
 import eterea.core.service.hexagonal.empresa.infrastructure.web.dto.EmpresaResponse;
 import eterea.core.service.hexagonal.empresa.infrastructure.web.mapper.EmpresaDtoMapper;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class EmpresaController {
 
-    private final GetLastEmpresaUseCase getLastEmpresaUseCase;
+    private final EmpresaService empresaService;
     private final EmpresaDtoMapper empresaDtoMapper;
 
     @GetMapping("/top")
     public ResponseEntity<EmpresaResponse> findTop() {
-        return getLastEmpresaUseCase
+        return empresaService
                 .findLast()
                 .map(empresa -> ResponseEntity.ok(empresaDtoMapper.toResponse(empresa)))
                 .orElse(ResponseEntity.notFound().build());

--- a/src/test/java/eterea/core/service/hexagonal/empresa/application/service/EmpresaServiceTest.java
+++ b/src/test/java/eterea/core/service/hexagonal/empresa/application/service/EmpresaServiceTest.java
@@ -1,7 +1,7 @@
 package eterea.core.service.hexagonal.empresa.application.service;
 
 import eterea.core.service.hexagonal.empresa.domain.model.Empresa;
-import eterea.core.service.hexagonal.empresa.domain.ports.out.EmpresaRepository;
+import eterea.core.service.hexagonal.empresa.domain.ports.in.GetLastEmpresaUseCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,55 +9,29 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
-import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EmpresaServiceTest {
 
     @Mock
-    private EmpresaRepository empresaRepository;
+    private GetLastEmpresaUseCase getLastEmpresaUseCase;
 
     @InjectMocks
     private EmpresaService empresaService;
 
     @Test
-    void findLast_WhenEmpresaExistsAndBusinessIdIsNotNull_ShouldReturnEmpresa() {
-        UUID businessId = UUID.randomUUID();
-        Empresa empresa = Empresa.builder().businessId(businessId).build();
-
-        when(empresaRepository.findLast()).thenReturn(Optional.of(empresa));
+    void findLast_ShouldDelegateToUseCase() {
+        Empresa empresa = Empresa.builder().build();
+        when(getLastEmpresaUseCase.findLast()).thenReturn(Optional.of(empresa));
 
         Optional<Empresa> result = empresaService.findLast();
 
-        assertTrue(result.isPresent());
-        assertEquals(businessId, result.get().getBusinessId());
-        verify(empresaRepository, never()).save(any());
+        assertEquals(Optional.of(empresa), result);
+        verify(getLastEmpresaUseCase).findLast();
     }
 
-    @Test
-    void findLast_WhenEmpresaExistsAndBusinessIdIsNull_ShouldGenerateUuidAndSave() {
-        Empresa empresa = Empresa.builder().businessId(null).build();
-
-        when(empresaRepository.findLast()).thenReturn(Optional.of(empresa));
-
-        Optional<Empresa> result = empresaService.findLast();
-
-        assertTrue(result.isPresent());
-        assertNotNull(result.get().getBusinessId());
-        verify(empresaRepository).save(empresa);
-    }
-
-    @Test
-    void findLast_WhenEmpresaDoesNotExist_ShouldReturnEmpty() {
-        when(empresaRepository.findLast()).thenReturn(Optional.empty());
-
-        Optional<Empresa> result = empresaService.findLast();
-
-        assertTrue(result.isEmpty());
-        verify(empresaRepository, never()).save(any());
-    }
 }

--- a/src/test/java/eterea/core/service/hexagonal/empresa/application/usecases/GetLastEmpresaUseCaseImplTest.java
+++ b/src/test/java/eterea/core/service/hexagonal/empresa/application/usecases/GetLastEmpresaUseCaseImplTest.java
@@ -1,0 +1,63 @@
+package eterea.core.service.hexagonal.empresa.application.usecases;
+
+import eterea.core.service.hexagonal.empresa.domain.model.Empresa;
+import eterea.core.service.hexagonal.empresa.domain.ports.out.EmpresaRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetLastEmpresaUseCaseImplTest {
+
+    @Mock
+    private EmpresaRepository empresaRepository;
+
+    @InjectMocks
+    private GetLastEmpresaUseCaseImpl getLastEmpresaUseCase;
+
+    @Test
+    void findLast_WhenEmpresaExistsAndBusinessIdIsNotNull_ShouldReturnEmpresa() {
+        UUID businessId = UUID.randomUUID();
+        Empresa empresa = Empresa.builder().businessId(businessId).build();
+
+        when(empresaRepository.findLast()).thenReturn(Optional.of(empresa));
+
+        Optional<Empresa> result = getLastEmpresaUseCase.findLast();
+
+        assertTrue(result.isPresent());
+        assertEquals(businessId, result.get().getBusinessId());
+        verify(empresaRepository, never()).save(any());
+    }
+
+    @Test
+    void findLast_WhenEmpresaExistsAndBusinessIdIsNull_ShouldGenerateUuidAndSave() {
+        Empresa empresa = Empresa.builder().businessId(null).build();
+
+        when(empresaRepository.findLast()).thenReturn(Optional.of(empresa));
+
+        Optional<Empresa> result = getLastEmpresaUseCase.findLast();
+
+        assertTrue(result.isPresent());
+        assertNotNull(result.get().getBusinessId());
+        verify(empresaRepository).save(empresa);
+    }
+
+    @Test
+    void findLast_WhenEmpresaDoesNotExist_ShouldReturnEmpty() {
+        when(empresaRepository.findLast()).thenReturn(Optional.empty());
+
+        Optional<Empresa> result = getLastEmpresaUseCase.findLast();
+
+        assertTrue(result.isEmpty());
+        verify(empresaRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
Closes #180

## Descripción

Refactorización del módulo `Empresa` para alinearlo completamente con la arquitectura hexagonal del proyecto, junto con la preparación de la release v2.3.1.

## Cambios Realizados

- **Extracción de caso de uso**: Nuevo `GetLastEmpresaUseCaseImpl` con lógica de generación de UUID y persistencia, extraída de `EmpresaService`.
- **Renombrado de repositorios**: `EmpresaJpaRepository` → `JpaEmpresaRepository`, `EmpresaJpaRepositoryAdapter` → `JpaEmpresaRepositoryAdapter`.
- **Simplificación de `EmpresaService`**: Ahora orquesta delegando en `GetLastEmpresaUseCase`.
- **Actualización de `EmpresaController`**: Inyecta `EmpresaService` en lugar del use case directamente.
- **Tests**: Nuevo `GetLastEmpresaUseCaseImplTest` (3 casos) y simplificación de `EmpresaServiceTest`.
- **Versionado**: Bump `2.3.0` → `2.3.1` en `pom.xml`, actualización de `CHANGELOG.md`, `README.md`.
- **Documentación**: Diagrama de clases actualizado.

## Verificación

- `mvn test` - Todos los tests existentes y nuevos pasan correctamente.
- Los casos de prueba cubren: empresa con businessId, empresa sin businessId (genera UUID), empresa no encontrada.
- `EmpresaServiceTest` verifica delegación al use case.
