### PR TITLE
chore(release): bump to v2.4.1 with null-safety, refactor and Kotlin 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [2.4.1] - 2026-06-06
+
+### Fixed
+- **fix(mapper)**: Null-safety improvements en `ArticuloMovimientoMapper` para campos `stockMovimientoId`, `tenenciaMovimientoId`, `nivel`, `cierreCajaId`, `cierreRestaurantId`, `mozoId`, `precioValuacion`, `comision`, `totalConIva` y `totalSinIva` — prevención de NPEs con valores nulos del dominio
+- **fix(error-handling)**: Mejora en manejo de excepciones en `MakeFacturaProgramaDiaService` añadiendo captura genérica de `Exception` para errores imprevistos en envío de email
+
+### Changed
+- **refactor(controller)**: Sustitución de constructor manual por `@RequiredArgsConstructor` en `ConceptoFacturadoController`
+- **refactor(mapper)**: Sustitución de constructor manual por `@RequiredArgsConstructor` en `ArticuloMovimientoMapper`
+- **refactor(service)**: Sustitución de constructor manual por `@RequiredArgsConstructor` en `ConceptoFacturadoService`
+- **refactor(service)**: Adición de `@Slf4j` en `GetInvoiceDataByClienteMovimientoIdImpl`
+- **refactor(dto)**: Adición del método `jsonify()` en `RegistroCaeResponse` para serialización JSON consistente
+- **refactor(logging)**: Mejora de mensajes de depuración con formato estructurado (`\n\n`) en `ArticuloMovimientoService`, `AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl`, `GetInvoiceDataByClienteMovimientoIdImpl`, `InvoiceDataMapper`, `FacturacionService`, `MakeFacturaProgramaDiaService`, `VouchersService` y `ProductsService`
+
+### Dependencies
+- **chore(deps)**: Actualización de Kotlin 2.3.21 → 2.4.0 en `pom.xml`
+
 ## [2.4.0] - 2026-06-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![ETEREA.core-service CI](https://github.com/ETEREA-services/ETEREA.core-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.core-service/actions/workflows/maven.yml)
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/javase/jdk25-archive-downloads.html)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-blueviolet.svg)](https://kotlinlang.org/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-blueviolet.svg)](https://kotlinlang.org/)
 
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-green.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-green.svg)](https://spring.io/projects/spring-cloud)
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.6.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.4.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.4.1-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 
@@ -25,7 +25,7 @@ Servicio Core para la gestión financiera y contable, implementado con **arquite
 
 ## Stack Tecnológico
 
-- **Java 25** y **Kotlin 2.3.21**
+- **Java 25** y **Kotlin 2.4.0**
 - **Spring Boot 4.0.6** con Spring Cloud 2025.1.0
 - **Arquitectura Hexagonal** para modularidad y testabilidad
 - **Consul Discovery** y **OpenFeign**

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>
         <java.version>25</java.version>
-        <kotlin.version>2.3.21</kotlin.version>
+        <kotlin.version>2.4.0</kotlin.version>
         <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>eterea-services</sonar.organization>
         <sonar.projectKey>ETEREA-services_ETEREA.core-service</sonar.projectKey>

--- a/src/main/java/eterea/core/service/controller/ConceptoFacturadoController.java
+++ b/src/main/java/eterea/core/service/controller/ConceptoFacturadoController.java
@@ -3,6 +3,7 @@ package eterea.core.service.controller;
 import eterea.core.service.kotlin.exception.ConceptoFacturadoException;
 import eterea.core.service.kotlin.model.ConceptoFacturado;
 import eterea.core.service.service.ConceptoFacturadoService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,18 +14,15 @@ import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping({"/api/core/conceptoFacturado", "/conceptoFacturado"})
+@RequiredArgsConstructor
 public class ConceptoFacturadoController {
 
     private final ConceptoFacturadoService service;
 
-    public ConceptoFacturadoController(ConceptoFacturadoService service) {
-        this.service = service;
-    }
-
     @GetMapping("/articuloMovimiento/{articuloMovimientoId}")
     public ResponseEntity<ConceptoFacturado> findByArticuloMovimientoId(@PathVariable Long articuloMovimientoId) {
         try {
-            return new ResponseEntity<>(service.findByArticuloMovimientoId(articuloMovimientoId), HttpStatus.OK);
+            return ResponseEntity.ok(service.findByArticuloMovimientoId(articuloMovimientoId));
         } catch (ConceptoFacturadoException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }

--- a/src/main/java/eterea/core/service/hexagonal/articulomovimiento/application/service/ArticuloMovimientoService.java
+++ b/src/main/java/eterea/core/service/hexagonal/articulomovimiento/application/service/ArticuloMovimientoService.java
@@ -22,7 +22,7 @@ public class ArticuloMovimientoService {
     private final AutoCompleteTotalesByClienteMovimientoIdUseCase autoComplete;
 
     public List<ArticuloMovimiento> findAllByClienteMovimientoId(Long clienteMovimientoId) {
-        log.debug("Processing ArticuloMovimientoService.findAllByClienteMovimientoId: {}", clienteMovimientoId);
+        log.debug("\n\nProcessing ArticuloMovimientoService.findAllByClienteMovimientoId: {}\n\n", clienteMovimientoId);
         autoCompleteTotalesByClienteMovimientoId(clienteMovimientoId);
         return getByClienteMovimientoId.findAllByClienteMovimientoId(clienteMovimientoId);
     }
@@ -44,6 +44,7 @@ public class ArticuloMovimientoService {
     }
 
     public List<ArticuloMovimiento> autoCompleteTotalesByClienteMovimientoId(Long clienteMovimientoId) {
+        log.debug("\n\nProcessing ArticuloMovimientoService.autoCompleteTotalesByClienteMovimientoId\n\n");
         return autoComplete.calculateTotalesByClienteMovimientoId(clienteMovimientoId);
     }
 

--- a/src/main/java/eterea/core/service/hexagonal/articulomovimiento/application/usecases/AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl.java
+++ b/src/main/java/eterea/core/service/hexagonal/articulomovimiento/application/usecases/AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl.java
@@ -21,9 +21,9 @@ public class AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl implements Auto
 
     @Override
     public List<ArticuloMovimiento> calculateTotalesByClienteMovimientoId(Long clienteMovimientoId) {
-        log.debug("Processing AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl.calculateTotalesByClienteMovimientoId");
+        log.debug("\n\nProcessing AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl.calculateTotalesByClienteMovimientoId\n\n");
         List<ArticuloMovimiento> movimientos = repository.findAllByClienteMovimientoId(clienteMovimientoId);
-        log.debug("ArticuloMovimientos -> {}", Jsonifier.builder(movimientos).build());
+        log.debug("\n\nArticuloMovimientos -> {}\n\n", Jsonifier.builder(movimientos).build());
         movimientos.forEach(movimiento -> {
             var tasaImpuesto = movimiento.getPrecioUnitarioConIva().divide(movimiento.getPrecioUnitarioSinIva(), 3, RoundingMode.HALF_UP);
             if (movimiento.getTotalConIva().compareTo(BigDecimal.ZERO) == 0) {
@@ -32,9 +32,9 @@ public class AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl implements Auto
             if (movimiento.getTotalSinIva().compareTo(BigDecimal.ZERO) == 0) {
                 movimiento.setTotalSinIva(movimiento.getTotalConIva().divide(tasaImpuesto, 4, RoundingMode.HALF_UP));
             }
-            log.debug("ArticuloMovimiento -> {}", movimiento.jsonify());
+            log.debug("\n\nArticuloMovimiento -> {}\n\n", movimiento.jsonify());
         });
-        log.debug("ArticuloMovimientos updated -> {}", Jsonifier.builder(movimientos).build());
+        log.debug("\n\nArticuloMovimientos updated -> {}\n\n", Jsonifier.builder(movimientos).build());
         movimientos = repository.saveAll(movimientos);
         return movimientos;
     }

--- a/src/main/java/eterea/core/service/hexagonal/articulomovimiento/infrastructure/persistence/mapper/ArticuloMovimientoMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/articulomovimiento/infrastructure/persistence/mapper/ArticuloMovimientoMapper.java
@@ -3,16 +3,16 @@ package eterea.core.service.hexagonal.articulomovimiento.infrastructure.persiste
 import eterea.core.service.hexagonal.articulo.infrastructure.persistence.mapper.ArticuloMapper;
 import eterea.core.service.hexagonal.articulomovimiento.domain.model.ArticuloMovimiento;
 import eterea.core.service.hexagonal.articulomovimiento.infrastructure.persistence.entity.ArticuloMovimientoEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+
 @Component
+@RequiredArgsConstructor
 public class ArticuloMovimientoMapper {
 
     private final ArticuloMapper articuloMapper;
-
-    public ArticuloMovimientoMapper(ArticuloMapper articuloMapper) {
-        this.articuloMapper = articuloMapper;
-    }
 
     public ArticuloMovimiento toDomain(ArticuloMovimientoEntity entity) {
         if (entity == null) return null;
@@ -54,8 +54,8 @@ public class ArticuloMovimientoMapper {
         return ArticuloMovimientoEntity.builder()
                 .articuloMovimientoId(domain.getArticuloMovimientoId())
                 .clienteMovimientoId(domain.getClienteMovimientoId())
-                .stockMovimientoId(domain.getStockMovimientoId())
-                .tenenciaMovimientoId(domain.getTenenciaMovimientoId())
+                .stockMovimientoId(domain.getStockMovimientoId() == null ? 0 : domain.getStockMovimientoId())
+                .tenenciaMovimientoId(domain.getTenenciaMovimientoId() == null ? 0 : domain.getTenenciaMovimientoId())
                 .centroStockId(domain.getCentroStockId())
                 .comprobanteId(domain.getComprobanteId())
                 .item(domain.getItem())
@@ -70,16 +70,16 @@ public class ArticuloMovimientoMapper {
                 .exento(domain.getExento())
                 .fechaMovimiento(domain.getFechaMovimiento())
                 .fechaFactura(domain.getFechaFactura())
-                .nivel(domain.getNivel())
-                .cierreCajaId(domain.getCierreCajaId())
-                .cierreRestaurantId(domain.getCierreRestaurantId())
+                .nivel(domain.getNivel() == null ? 0 : domain.getNivel())
+                .cierreCajaId(domain.getCierreCajaId() == null ? 0 : domain.getCierreCajaId())
+                .cierreRestaurantId(domain.getCierreRestaurantId()  == null ? 0 : domain.getCierreRestaurantId())
                 .precioCompra(domain.getPrecioCompra())
-                .precioValuacion(domain.getPrecioValuacion())
-                .mozoId(domain.getMozoId())
-                .comision(domain.getComision())
+                .precioValuacion(domain.getPrecioValuacion() == null ? BigDecimal.ZERO : domain.getPrecioValuacion())
+                .mozoId(domain.getMozoId() == null ? 0 : domain.getMozoId())
+                .comision(domain.getComision() == null ? BigDecimal.ZERO : domain.getComision())
                 .trackUuid(domain.getTrackUuid())
-                .totalConIva(domain.getTotalConIva())
-                .totalSinIva(domain.getTotalSinIva())
+                .totalConIva(domain.getTotalConIva() == null ? BigDecimal.ZERO : domain.getTotalConIva())
+                .totalSinIva(domain.getTotalSinIva() == null ? BigDecimal.ZERO : domain.getTotalSinIva())
                 .articulo(articuloMapper.toEntity(domain.getArticulo()))
                 .build();
     }

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/application/usecases/GetInvoiceDataByClienteMovimientoIdImpl.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/application/usecases/GetInvoiceDataByClienteMovimientoIdImpl.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class GetInvoiceDataByClienteMovimientoIdImpl implements GetInvoiceDataByClienteMovimientoId {
 
@@ -18,21 +19,27 @@ public class GetInvoiceDataByClienteMovimientoIdImpl implements GetInvoiceDataBy
 
     @Override
     public InvoiceData getInvoiceDataByClienteMovimientoId(Long clienteMovimientoId) {
+        log.debug("\n\nProcessing GetInvoiceDataByClienteMovimientoIdImpl\n\n");
         var clienteMovimiento = clienteMovimientoService.findByClienteMovimientoId(clienteMovimientoId);
+        log.debug("\n\nClienteMovimiento -> {}\n\n", clienteMovimiento.jsonify());
         var registroCae = registroCaeService.findByUnique(
                 clienteMovimiento.getComprobanteId(),
                 clienteMovimiento.getPuntoVenta(),
                 clienteMovimiento.getNumeroComprobante());
+        log.debug("\n\nRegistroCae -> {}\n\n", registroCae.jsonify());
         ClienteMovimiento clienteMovimientoAsociado = null;
         if (registroCae.getClienteMovimientoIdAsociado() != null) {
             clienteMovimientoAsociado = clienteMovimientoService.findByClienteMovimientoId(registroCae.getClienteMovimientoIdAsociado());
+            log.debug("\n\nClienteMovimientoAsociado -> {}\n\n", clienteMovimientoAsociado.jsonify());
         }
 
-        return InvoiceData.builder()
+        var invoiceData = InvoiceData.builder()
                 .clienteMovimiento(clienteMovimiento)
                 .registroCae(registroCae)
                 .clienteMovimientoAsociado(clienteMovimientoAsociado)
                 .build();
+        log.debug("\n\nInvoiceData -> {}\n\n", invoiceData.jsonify());
+        return invoiceData;
     }
 
 }

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/RegistroCaeResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/dto/RegistroCaeResponse.java
@@ -1,5 +1,6 @@
 package eterea.core.service.hexagonal.invoicedata.infrastructure.dto;
 
+import eterea.core.service.tool.Jsonifier;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,5 +20,9 @@ public class RegistroCaeResponse {
     private String caeVencimiento;
     private String fecha;
     private ComprobanteResponse comprobante;
+
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
 
 }

--- a/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/InvoiceDataMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/invoicedata/infrastructure/mapper/InvoiceDataMapper.java
@@ -15,17 +15,25 @@ public class InvoiceDataMapper {
     private final RegistroCaeMapper registroCaeMapper;
 
     public InvoiceDataResponse toResponse(InvoiceData invoiceData) {
+        log.debug("\n\nProcessing InvoiceDataMapper.toResponse\n\n");
         if (invoiceData == null) {
             return null;
         }
         var clienteMovimiento = clienteMovimientoMapper.toResponse(invoiceData.getClienteMovimiento());
+        log.debug("\n\nClienteMovimiento -> {}\n\n", clienteMovimiento.jsonify());
         var registroCae = registroCaeMapper.toResponse(invoiceData.getRegistroCae());
+        log.debug("\n\nRegistroCae -> {}\n\n", registroCae.jsonify());
         var clienteMovimientoAsociado = clienteMovimientoMapper.toResponse(invoiceData.getClienteMovimientoAsociado());
-        return InvoiceDataResponse.builder()
+        if (clienteMovimientoAsociado != null) {
+            log.debug("\n\nClienteMovimientoAsociado -> {}\n\n", clienteMovimientoAsociado.jsonify());
+        }
+        var invoiceDataResponse = InvoiceDataResponse.builder()
                 .clienteMovimiento(clienteMovimiento)
                 .registroCae(registroCae)
                 .clienteMovimientoAsociado(clienteMovimientoAsociado)
                 .build();
+        log.debug("\n\nInvoiceDataResponse -> {}\n\n", invoiceDataResponse.jsonify());
+        return invoiceDataResponse;
     }
 
 }

--- a/src/main/java/eterea/core/service/service/ConceptoFacturadoService.java
+++ b/src/main/java/eterea/core/service/service/ConceptoFacturadoService.java
@@ -6,6 +6,7 @@ package eterea.core.service.service;
 import eterea.core.service.kotlin.exception.ConceptoFacturadoException;
 import eterea.core.service.kotlin.model.ConceptoFacturado;
 import eterea.core.service.kotlin.repository.ConceptoFacturadoRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -15,13 +16,10 @@ import java.util.Objects;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class ConceptoFacturadoService {
 
 	private final ConceptoFacturadoRepository repository;
-
-	public ConceptoFacturadoService(ConceptoFacturadoRepository repository) {
-		this.repository = repository;
-	}
 
 	public ConceptoFacturado findByArticuloMovimientoId(Long articuloMovimientoId) {
 		return Objects.requireNonNull(repository.findTopByArticuloMovimientoId(articuloMovimientoId)).orElseThrow(() -> new ConceptoFacturadoException(articuloMovimientoId));

--- a/src/main/java/eterea/core/service/service/facade/FacturacionService.java
+++ b/src/main/java/eterea/core/service/service/facade/FacturacionService.java
@@ -67,11 +67,11 @@ public class FacturacionService {
                                                                    ReservaContext reservaContext,
                                                                    Track track,
                                                                    Boolean soloFactura) {
-        log.debug("Processing FacturacionService.registraTransaccionFacturaProgramaDia");
+        log.debug("\n\nProcessing FacturacionService.registraTransaccionFacturaProgramaDia\n\n");
         Voucher voucher = voucherService.findByVoucherId(reserva.getVoucherId());
-        log.debug("Voucher -> {}", voucher.jsonify());
+        log.debug("\n\nVoucher -> {}\n\n", voucher.jsonify());
         OrderNote orderNote = orderNoteService.findByOrderNumberId(Long.valueOf(Objects.requireNonNull(voucher.getNumeroVoucher())));
-        log.debug("OrderNote -> {}", orderNote.jsonify());
+        log.debug("\n\nOrderNote -> {}\n\n", orderNote.jsonify());
 
         // Mapea las formas de pago
         int valorId = 0;
@@ -126,7 +126,7 @@ public class FacturacionService {
         }
 
         var reservaArticulos = reservaArticuloService.findAllByReservaId(reserva.getReservaId());
-        log.debug("Reserva Articulos cargados");
+        log.debug("\n\nReserva Articulos cargados\n\n");
 
         var clienteMovimiento = registraFacturaService.registraFacturaCompleta(
                 empresa,
@@ -141,7 +141,7 @@ public class FacturacionService {
                 reservaArticulos,
                 parametro
         );
-        log.debug("ClienteMovimiento -> {}", clienteMovimiento.jsonify());
+        log.debug("\n\nClienteMovimiento -> {}\n\n", clienteMovimiento.jsonify());
 
         if (soloFactura == true) {
             return clienteMovimiento;
@@ -150,19 +150,19 @@ public class FacturacionService {
         // Registra reservaContext
         reservaContext.setClienteMovimientoId(clienteMovimiento.getClienteMovimientoId());
         reservaContext = reservaContextService.update(reservaContext, reservaContext.getReservaContextId());
-        log.debug("ReservaContext -> {}", reservaContext.jsonify());
+        log.debug("\n\nReservaContext -> {}\n\n", reservaContext.jsonify());
 
         reserva.setFacturada((byte) 1);
         reserva.setVerificada((byte) 1);
         reserva = reservaService.update(reserva, reserva.getReservaId());
-        log.debug("Reserva -> {}", reserva.jsonify());
+        log.debug("\n\nReserva -> {}\n\n", reserva.jsonify());
 
         voucher.setConfirmado((byte) 1);
         voucher = voucherService.update(voucher, voucher.getVoucherId());
-        log.debug("Voucher -> {}", voucher.jsonify());
+        log.debug("\n\nVoucher -> {}\n\n", voucher.jsonify());
 
         track = trackService.endTracking(track);
-        log.debug("Track -> {}", track.jsonify());
+        log.debug("\n\nTrack -> {}\n\n", track.jsonify());
 
         return clienteMovimiento;
 

--- a/src/main/java/eterea/core/service/service/facade/MakeFacturaProgramaDiaService.java
+++ b/src/main/java/eterea/core/service/service/facade/MakeFacturaProgramaDiaService.java
@@ -57,6 +57,7 @@ public class MakeFacturaProgramaDiaService {
     private final ArticuloMapper articuloMapper;
 
     public boolean facturaReserva(Long reservaId, Integer comprobanteId, Track track) {
+        log.debug("\n\nProcessing MakeFacturaProgramaDiaService.facturaReserva\n\n");
         if (track == null) {
             track = trackService.startTracking("factura-reserva");
         }
@@ -64,13 +65,13 @@ public class MakeFacturaProgramaDiaService {
         if (comprobante.getFacturaElectronica() == 0) {
             return false;
         }
-        log.debug("Comprobante -> {}", comprobante.jsonify());
+        log.debug("\n\nComprobante -> {}\n\n", comprobante.jsonify());
         Empresa empresa = empresaService.findLast()
                 .orElseThrow(EmpresaException::new);
         Parametro parametro = parametroService.findTop();
         String moneda = "PES";
         Reserva reserva = reservaService.findByReservaId(reservaId);
-        log.debug("Reserva -> {}", reserva.jsonify());
+        log.debug("\n\nReserva -> {}\n\n", reserva.jsonify());
         if (reserva.getFacturada() == (byte) 1) {
             log.debug("reserva facturada={}", reserva.getReservaId());
             try {
@@ -79,14 +80,14 @@ public class MakeFacturaProgramaDiaService {
                 reservaContext.setFacturaPendiente((byte) 0);
                 reservaContext.setEnvioPendiente((byte) 0);
                 reservaContext = reservaContextService.update(reservaContext, reservaContext.getReservaContextId());
-                log.debug("ReservaContext -> {}", reservaContext.jsonify());
+                log.debug("\n\nReservaContext -> {}\n\n", reservaContext.jsonify());
             } catch (ReservaContextException e) {
                 log.debug("No hay reserva_context para esta reserva");
             }
             return false;
         }
         Voucher voucher = voucherService.findByVoucherId(reserva.getVoucherId());
-        log.debug("Voucher -> {}", voucher.jsonify());
+        log.debug("\n\nVoucher -> {}\n\n", voucher.jsonify());
         Cliente cliente = clienteService.findByClienteId(reserva.getClienteId());
         PosicionIva posicionIva = cliente.getPosicion();
         var idPosicionIvaArca = 5;
@@ -131,7 +132,7 @@ public class MakeFacturaProgramaDiaService {
         BigDecimal exento = BigDecimal.ZERO;
         for (ReservaArticulo reservaArticulo : reservaArticuloService.findAllByReservaId(reservaId)) {
             reservaArticulo.setArticulo(articuloMapper.toEntity(articuloService.findByArticuloId(reservaArticulo.getArticuloId())));
-            log.debug("ReservaArticulo -> {}", reservaArticulo.jsonify());
+            log.debug("\n\nReservaArticulo -> {}\n\n", reservaArticulo.jsonify());
             BigDecimal subtotal = reservaArticulo.getPrecioUnitario().multiply(new BigDecimal(reservaArticulo.getCantidad()));
             total = total.add(subtotal);
             if (Objects.requireNonNull(reservaArticulo.getArticulo()).getExento() == (byte) 1) {
@@ -159,11 +160,11 @@ public class MakeFacturaProgramaDiaService {
                     .build();
             reservaContext = reservaContextService.add(reservaContext);
         }
-        log.debug("ReservaContext -> {}", reservaContext.jsonify());
+        log.debug("\n\nReservaContext -> {}\n\n", reservaContext.jsonify());
 
         // Chequeo si la reserva ya pasó por ARCA
         if (reservaContext.getFacturaArca() == (byte) 1) {
-            log.info("Reserva {} Order Number {} facturada en ARCA sin registro", reservaId, reservaContext.getOrderNumberId());
+            log.info("\n\nReserva {} Order Number {} facturada en ARCA sin registro\n\n", reservaId, reservaContext.getOrderNumberId());
             return false;
         }
 
@@ -190,26 +191,26 @@ public class MakeFacturaProgramaDiaService {
                 .iva105(iva105.setScale(2, RoundingMode.HALF_UP))
                 .idCondicionIva(idPosicionIvaArca)
                 .build();
-        log.debug("FacturacionDto -> {}", facturacionDto.jsonify());
+        log.debug("\n\nFacturacionDto -> {}\n\n", facturacionDto.jsonify());
 
         try {
             facturacionDto = facturacionElectronicaService.makeFactura(facturacionDto);
-            log.debug("After makeFactura -> {}", facturacionDto.jsonify());
+            log.debug("\n\nAfter makeFactura -> {}\n\n", facturacionDto.jsonify());
         } catch (WebClientResponseException e) {
-            log.debug("Servicio de Facturación NO disponible");
+            log.debug("\n\nServicio de Facturación NO disponible\n\n");
             reservaContext = reservaContextService.update(reservaContext, reservaContext.getReservaContextId());
-            log.debug("ReservaContext -> {}", reservaContext.jsonify());
+            log.debug("\n\nReservaContext -> {}\n\n", reservaContext.jsonify());
             return false;
         }
 
         if (!facturacionDto.getResultado().equals("A")) {
             reservaContext = reservaContextService.update(reservaContext, reservaContext.getReservaContextId());
-            log.debug("Facturación NO Aprobada por ARCA -> {}", reservaContext.jsonify());
+            log.debug("\n\nFacturación NO Aprobada por ARCA -> {}\n\n", reservaContext.jsonify());
             return false;
         }
 
         var orderNote = orderNoteService.findByOrderNumberId(reservaContext.getOrderNumberId());
-        log.debug("Recuperando order_note -> {}", orderNote.jsonify());
+        log.debug("\n\nRecuperando order_note -> {}\n\n", orderNote.jsonify());
 
         reservaContext = registraFacturaService.markReservaContextFacturada(reservaContext, orderNote, facturacionDto);
 
@@ -254,7 +255,7 @@ public class MakeFacturaProgramaDiaService {
                 .trackUuid(track.getUuid())
                 .build();
         registroCae = registroCaeService.add(registroCae);
-        log.debug("RegistroCae -> {}", registroCae.jsonify());
+        log.debug("\n\nRegistroCae -> {}\n\n", registroCae.jsonify());
 
         ClienteMovimiento clienteMovimiento = null;
         try {
@@ -278,9 +279,12 @@ public class MakeFacturaProgramaDiaService {
 
         if (clienteMovimiento != null) {
             var enableSendEmail = Boolean.parseBoolean(environment.getProperty("app.enable-send-email", "true"));
+            log.debug("\n\nenableSendMail -> {}\n\n", enableSendEmail);
             if (enableSendEmail) {
                 if (clienteMovimiento.getClienteMovimientoId() != null) {
+                    log.debug("\n\nTratando de enviar clienteMovimientoId -> {}\n\n", clienteMovimiento.getClienteMovimientoId());
                     try {
+                        log.debug("\n\nIncrementando tries\n\n");
                         reservaContext.setEnvioTries(1 + reservaContext.getEnvioTries());
                         log.debug("envío correo={}", makeFacturaReportClient.send(clienteMovimiento.getClienteMovimientoId(), "daniel.quinterospinto@gmail.com"));
                         reservaContext.setEnvioPendiente((byte) 0);
@@ -290,6 +294,8 @@ public class MakeFacturaProgramaDiaService {
                     } catch (MessagingException e) {
                         reservaContext = reservaContextService.update(reservaContext, reservaContext.getReservaContextId());
                         log.debug("Error send ReservaContext -> {}", reservaContext.jsonify());
+                    } catch (Exception e) {
+                        log.debug("Error desconocido -> {}", e.getMessage());
                     }
                 }
             }

--- a/src/main/java/eterea/core/service/service/facade/VouchersService.java
+++ b/src/main/java/eterea/core/service/service/facade/VouchersService.java
@@ -29,12 +29,12 @@ public class VouchersService {
     private final EmpresaService empresaService;
 
     public ProgramaDiaDto importOneFromWeb(Long orderNumberId, Track track) {
-        log.debug("Processing importOneFromWeb");
+        log.debug("\n\nProcessing importOneFromWeb\n\n");
         OrderNote orderNote = getOrderNoteById(orderNumberId);
         if (orderNote == null || !isOrderCompleted(orderNote)) {
             return createErrorResponse("Error: Order Note pendiente de PAGO");
         }
-        log.debug("OrderNote -> {}", orderNote.jsonify());
+        log.debug("\n\nOrderNote -> {}\n\n", orderNote.jsonify());
 
         if (isVoucherAlreadyRegistered(orderNumberId)) {
             return createErrorResponse("Error: Programa por el Día YA registrado");
@@ -89,7 +89,7 @@ public class VouchersService {
     }
 
     private ProgramaDiaDto processProduct(OrderNote orderNote, Product product, Negocio negocio, Track track) {
-        log.debug("Processing VouchersService.processProduct");
+        log.debug("\n\nProcessing VouchersService.processProduct\n\n");
         switch (product.getSku()) {
             case "parque_termal":
             case "tarde_termaspa":

--- a/src/main/java/eterea/core/service/service/facade/reserva/ProductsService.java
+++ b/src/main/java/eterea/core/service/service/facade/reserva/ProductsService.java
@@ -45,7 +45,7 @@ public class ProductsService {
 
     @Transactional
     public ProgramaDiaDto processOneProduct(OrderNote orderNote, Integer proveedorId, Integer hotelId, Product product, Negocio negocio, Track track) {
-        log.debug("Processing facturaUnProducto");
+        log.debug("\n\nProcessing facturaUnProducto\n\n");
         if (track == null) {
             track = trackService.startTracking("factura-un-producto");
         }
@@ -185,7 +185,7 @@ public class ProductsService {
 
     @Transactional
     public Voucher registrarVoucher(Voucher voucher, List<VoucherProducto> voucherProductos, Track track) {
-        log.debug("Processing registrarVoucher");
+        log.debug("\n\nProcessing registrarVoucher\n\n");
         if (track == null) {
             track = trackService.startTracking("registro-voucher");
         }


### PR DESCRIPTION
Closes #184

## Descripción

Release **v2.4.1** con correcciones de null-safety, refactorización a `@RequiredArgsConstructor`, mejora de logging y actualización de dependencias.

## Cambios Realizados

- **fix(mapper):** Null-safety en `ArticuloMovimientoMapper` — valores nulos con fallback a `0` o `BigDecimal.ZERO`
- **fix(error-handling):** Captura genérica de `Exception` en `MakeFacturaProgramaDiaService` para errores de email
- **refactor(*):** Sustitución de constructores manuales por `@RequiredArgsConstructor` en controllers, services y mappers
- **refactor(logging):** Logs estructurados con delimitadores `\n\n` en servicios clave
- **refactor(dto):** Método `jsonify()` en `RegistroCaeResponse`
- **refactor(controller):** Uso de `ResponseEntity.ok()` en `ConceptoFacturadoController`
- **deps:** Actualización de Kotlin `2.3.21` → `2.4.0`
- **chore(release):** Bump de versión `2.4.0` → `2.4.1`

## Verificación

- Compilación exitosa con `mvn clean compile`
- Pruebas unitarias y de integración pasando
- Revisión de null-safety en mapeos de dominio
