### PR TITLE
refactor(articulo-barra): replace constructors and simplify logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.4.3] - 2026-06-10
+
+### Changed
+- **refactor(controller)**: Sustitución de constructor manual por `@RequiredArgsConstructor` en `ArticuloBarraController`
+- **refactor(service)**: Sustitución de constructor manual por `@RequiredArgsConstructor` en `ArticuloBarraService`
+- **refactor(logging)**: Refactor de logging en `ArticuloBarraService` — reemplazo del método privado `logArticuloBarra()` (basado en `JsonMapper`) por `log.debug` con `jsonify()` inline, eliminando dependencias no utilizadas (`Objects`, `JsonMapper`, `JsonProcessingException`)
+
 ## [2.4.2] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.6.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.4.2-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.4.3-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/controller/ArticuloBarraController.java
+++ b/src/main/java/eterea/core/service/controller/ArticuloBarraController.java
@@ -3,6 +3,7 @@ package eterea.core.service.controller;
 import eterea.core.service.kotlin.exception.ArticuloBarraException;
 import eterea.core.service.kotlin.model.ArticuloBarra;
 import eterea.core.service.service.ArticuloBarraService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,13 +15,10 @@ import java.util.List;
 @RestController
 @RequestMapping({"/api/core/articulobarra", "/articulobarra"})
 @Slf4j
+@RequiredArgsConstructor
 public class ArticuloBarraController {
 
     private final ArticuloBarraService service;
-
-    public ArticuloBarraController(ArticuloBarraService service) {
-        this.service = service;
-    }
 
     @GetMapping("/articulo/{articuloId}")
     public ResponseEntity<List<ArticuloBarra>> findAllByArticuloId(@PathVariable String articuloId) {

--- a/src/main/java/eterea/core/service/service/ArticuloBarraService.java
+++ b/src/main/java/eterea/core/service/service/ArticuloBarraService.java
@@ -6,6 +6,7 @@ import eterea.core.service.kotlin.exception.ArticuloBarraException;
 import eterea.core.service.kotlin.model.ArticuloBarra;
 import eterea.core.service.kotlin.repository.ArticuloBarraRepository;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -14,20 +15,20 @@ import java.util.Objects;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ArticuloBarraService {
 
     private final ArticuloBarraRepository repository;
-
-    public ArticuloBarraService(ArticuloBarraRepository repository) {
-        this.repository = repository;
-    }
 
     public List<ArticuloBarra> findAllByArticuloId(String articuloId) {
         return repository.findAllByArticuloId(articuloId);
     }
 
     public ArticuloBarra findByCodigoBarras(String codigoBarras) {
-        return Objects.requireNonNull(repository.findByCodigoBarras(codigoBarras)).orElseThrow(() -> new ArticuloBarraException(codigoBarras));
+        log.debug("\n\nProcessing ArticuloBarraService.findByCodigoBarras\n\n");
+        ArticuloBarra articuloBarra = repository.findByCodigoBarras(codigoBarras).orElseThrow(() -> new ArticuloBarraException(codigoBarras));
+        log.debug("\n\nArticuloBarra -> {}\n\n", articuloBarra.jsonify());
+        return articuloBarra;
     }
 
     @Transactional
@@ -36,18 +37,10 @@ public class ArticuloBarraService {
     }
 
     public ArticuloBarra add(ArticuloBarra articuloBarra) {
-        logArticuloBarra(articuloBarra);
+        log.debug("\n\nProcessing ArticuloBarraService.add\n\n");
         articuloBarra = repository.save(articuloBarra);
-        logArticuloBarra(articuloBarra);
+        log.debug("\n\nArticuloBarra -> {}\n\n", articuloBarra.jsonify());
         return articuloBarra;
-    }
-
-    private void logArticuloBarra(ArticuloBarra articuloBarra) {
-        try {
-            log.debug("ArticuloBarra -> {}", JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(articuloBarra));
-        } catch (JsonProcessingException e) {
-            log.debug("ArticuloBarra jsonify error -> {}", e.getMessage());
-        }
     }
 
 }


### PR DESCRIPTION
Closes #188

## Descripción

Refactor y preparación de release **v2.4.3**. Se sustituyen constructores manuales por `@RequiredArgsConstructor` de Lombok en `ArticuloBarraController` y `ArticuloBarraService`, se simplifica el logging eliminando dependencias de Jackson, y se actualiza la versión del proyecto.

## Cambios Realizados

- **pom.xml**: Bump de versión `2.4.2` → `2.4.3`
- **README.md**: Actualización de badge de versión
- **CHANGELOG.md**: Documentación del release v2.4.3
- **ArticuloBarraController.java**: Sustitución de constructor manual por `@RequiredArgsConstructor`
- **ArticuloBarraService.java**: Sustitución de constructor manual por `@RequiredArgsConstructor`, reemplazo de `logArticuloBarra()` por `log.debug` con `jsonify()` inline, eliminación de imports no utilizados (`Objects`, `JsonMapper`, `JsonProcessingException`)

## Verificación

- [ ] `mvn clean compile` — verifica compilación sin errores
- [ ] `mvn test` — tests unitarios pasan correctamente
- [ ] Revisar que el logging de `ArticuloBarraService` funcione sin `JsonMapper`
