### PR TITLE
fix(vouchers): renombrar SKU parque_termal a parque_termal_cacheuta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.4.4] - 2026-06-18
+
+### Changed
+- **fix(vouchers)**: Renombrado del SKU `parque_termal` → `parque_termal_cacheuta` en `VouchersService.processProduct()` para alinear el código con el nuevo SKU del producto web y de la tabla `producto_sku`.
+
 ## [2.4.3] - 2026-06-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.6.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.4.3-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.4.4-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.4</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/service/facade/VouchersService.java
+++ b/src/main/java/eterea/core/service/service/facade/VouchersService.java
@@ -91,7 +91,7 @@ public class VouchersService {
     private ProgramaDiaDto processProduct(OrderNote orderNote, Product product, Negocio negocio, Track track) {
         log.debug("\n\nProcessing VouchersService.processProduct\n\n");
         switch (product.getSku()) {
-            case "parque_termal":
+            case "parque_termal_cacheuta":
             case "tarde_termaspa":
                 return productsService.processOneProduct(orderNote, 130, 475, product, negocio, track);
             case "termaspa_fullday":


### PR DESCRIPTION
Closes #190

  ## Descripción

  Release **v2.4.4**. Renombra el SKU `parque_termal` → `parque_termal_cacheuta` en `VouchersService.processProduct()`.
  
  ## Cambios Realizados

  * **VouchersService.java**: `case "parque_termal"` → `"parque_termal_cacheuta"` (`parque_termal_traslado` queda intacto).
  * **pom.xml / README.md / CHANGELOG.md**: Bump de versión `2.4.3` → `2.4.4`.