### PR TITLE
fix(reserva): elimina duplicación de artículo compartido en reservaarticulo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.4.5] - 2026-06-29
+
+### Fixed
+- **fix(reserva)**: Corregida la duplicación del artículo compartido en `ReservaService.generarReservaArticulo`. La colección `collectionAgregar` se construía con la clave `Articulo::toString`, que al no existir un `@ToString` en `Articulo` devuelve el hash de identidad del objeto (único por instancia)
+
 ## [2.4.4] - 2026-06-28
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.4.4</version>
+    <version>2.4.5</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/service/ReservaService.java
+++ b/src/main/java/eterea/core/service/service/ReservaService.java
@@ -244,7 +244,7 @@ public class ReservaService {
         // Para eliminar parto de todos los que ya están guardados y sacaré los que hay que guardar que ya estaban, los que queden serán eliminados
         Map<String, ReservaArticulo> collectionEliminar = reservaArticuloService.findAllByVoucherId(reserva.getReservaId(), reserva.getVoucherId()).stream().collect(Collectors.toMap(ReservaArticulo::getArticuloId, reservaArticulo -> reservaArticulo));
         // Para agregar parto de todos los artículos que corresponden al voucher y elimino los que ya están guardados, los que queden seran agregados
-        Map<String, Articulo> collectionAgregar = articuloService.findAllByVoucher(voucherProductos).stream().collect(Collectors.toMap(Articulo::toString, Function.identity(), ((articulo, otherArticulo) -> articulo)));
+        Map<String, Articulo> collectionAgregar = articuloService.findAllByVoucher(voucherProductos).stream().collect(Collectors.toMap(Articulo::getArticuloId, Function.identity(), ((articulo, otherArticulo) -> articulo)));
 
         // Busco las claves a eliminar en ambas colecciones
         var claves = new ArrayList<String>();


### PR DESCRIPTION
**Closes #194**

### Descripción

Release **v2.4.5** que corrige la duplicación de un artículo compartido en `reservaarticulo` al importar reservas desde la web. El artículo, asociado a varios productos del voucher (PAX mayor y menor), se insertaba dos veces para el mismo `rar_art_id`.

### Cambios Realizados

- **fix(reserva)**: En `ReservaService.generarReservaArticulo`, la colección `collectionAgregar` se construía con la clave `Articulo::toString`. Como `Articulo` no define `@ToString`, `toString()` devuelve el hash de identidad del objeto (único por instancia)
- **chore(release)**: Version bump `2.4.4` → `2.4.5` en `pom.xml`
- **docs**: Nueva entrada `[2.4.5] - 2026-06-29` en `CHANGELOG.md`

### Verificación

- `mvn clean compile` — compilación exitosa
- `mvn test` — tests unitarios pasan
- Verificar que una reserva con PAX mayor y menor genere **una sola** fila de TRASLADO en `reservaarticulo` con `RAr_Cantidad` igual a la suma de paxs (no dos filas con la misma cantidad)