### PR TITLE
feat(articulomovimiento): Ampliación de DTOs y enriquecimiento de respuestas en cierre de caja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.5.1] - 2026-07-13
+
+### Features
+- **feat(articulomovimiento-dto)**: Ampliación de `ArticuloMovimientoResponse` con 14 campos nuevos: `tenenciaMovimientoId`, `numeroCuenta`, `iva105`, `exento`, `fechaFactura`, `nivel`, `cierreCajaId`, `cierreRestaurantId`, `precioCompra`, `precioValuacion`, `mozoId`, `comision`, `trackUuid` y `articulo` (objeto `ArticuloResponse`)
+- **feat(cierrecaja)**: Enriquecimiento de `PendingCountsDtoMapper` para poblar `articuloMovimientos` en `ClienteMovimientoResponse` y `StockMovimientoResponse` al construir `PendingCountsResponse` — los conteos pendientes de cierre de caja ahora incluyen los movimientos de artículos asociados
+- **feat(stockmovimiento-dto)**: Nuevo campo `articuloMovimientos: List<ArticuloMovimientoResponse>` en `StockMovimientoResponse`
+- **feat(clientemovimiento-dto)**: Nuevo campo `articuloMovimientos: List<ArticuloMovimientoResponse>` en `ClienteMovimientoResponse`
+
+### Changed
+- **refactor(articulomovimiento)**: `ArticuloMovimiento` implementa interfaz `Jsonifyable` en lugar de declarar método propio `jsonify()` — uso de serialización JSON centralizada
+- **refactor(articulomovimiento-mapper)**: `ArticuloMovimientoDtoMapper` migrado a `@RequiredArgsConstructor` con inyección de `ArticuloDtoMapper` para mapeo completo de nuevos campos
+
 ## [2.5.0] - 2026-07-12
 
 ### 🚀 Migración Masiva de Módulos a Arquitectura Hexagonal y Reorganización de Paquetes

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.7.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.5.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.5.1-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/docs/diagrams/mermaid/articulomovimiento-class-diagram.mmd
+++ b/docs/diagrams/mermaid/articulomovimiento-class-diagram.mmd
@@ -43,6 +43,7 @@ classDiagram
         +precioValuacion: BigDecimal
         +mozoId: Long
         +comision: BigDecimal
+        +trackUuid: String
         +articulo: Articulo
     }
 
@@ -112,7 +113,13 @@ classDiagram
     }
 
     class ArticuloMovimientoDtoMapper {
+        -ArticuloDtoMapper articuloDtoMapper
         +toResponse(ArticuloMovimiento): ArticuloMovimientoResponse
+    }
+
+    class ArticuloDtoMapper {
+        <<infrastructure>>
+        +toResponse(Articulo): ArticuloResponse
     }
 
     class ArticuloMovimientoResponse {
@@ -120,10 +127,30 @@ classDiagram
         +articuloMovimientoId: Long
         +clienteMovimientoId: Long
         +stockMovimientoId: Long
+        +tenenciaMovimientoId: Long
+        +centroStockId: Integer
+        +comprobanteId: Integer
+        +item: Integer
         +cantidad: BigDecimal
         +precioUnitario: BigDecimal
+        +precioUnitarioSinIva: BigDecimal
+        +precioUnitarioConIva: BigDecimal
+        +numeroCuenta: Long
+        +iva105: Byte
+        +exento: Byte
+        +fechaMovimiento: OffsetDateTime
+        +fechaFactura: OffsetDateTime
+        +nivel: Integer
+        +cierreCajaId: Long
+        +cierreRestaurantId: Long
+        +precioCompra: BigDecimal
+        +precioValuacion: BigDecimal
+        +mozoId: Long
+        +comision: BigDecimal
+        +trackUuid: String
         +totalConIva: BigDecimal
         +totalSinIva: BigDecimal
+        +articulo: ArticuloResponse
     }
 
     ArticuloMovimientoController --> ArticuloMovimientoService
@@ -144,3 +171,4 @@ classDiagram
     ArticuloMovimientoMapper --> ArticuloMovimiento
     ArticuloMovimientoDtoMapper --> ArticuloMovimientoResponse
     ArticuloMovimientoDtoMapper --> ArticuloMovimiento
+    ArticuloMovimientoDtoMapper --> ArticuloDtoMapper

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.4.5</version>
+    <version>2.5.1</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/hexagonal/cierrecaja/processCierre/infrastructure/web/mapper/PendingCountsDtoMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/cierrecaja/processCierre/infrastructure/web/mapper/PendingCountsDtoMapper.java
@@ -3,13 +3,19 @@ package eterea.core.service.hexagonal.cierrecaja.processCierre.infrastructure.we
 import eterea.core.service.hexagonal.cierrecaja.processCierre.domain.model.PendingCounts;
 import eterea.core.service.hexagonal.cierrecaja.processCierre.infrastructure.web.dto.PendingCountsResponse;
 import eterea.core.service.hexagonal.ventas.clientemovimiento.infrastructure.web.mapper.ClienteMovimientoDtoMapper;
+import eterea.core.service.hexagonal.ventas.clientemovimiento.infrastructure.web.dto.ClienteMovimientoResponse;
 import eterea.core.service.hexagonal.contable.cuentamovimiento.infrastructure.web.mapper.CuentaMovimientoDtoMapper;
 import eterea.core.service.hexagonal.stock.stockmovimiento.infrastructure.web.mapper.StockMovimientoDtoMapper;
+import eterea.core.service.hexagonal.stock.stockmovimiento.infrastructure.web.dto.StockMovimientoResponse;
+import eterea.core.service.hexagonal.stock.articulomovimiento.application.service.ArticuloMovimientoService;
+import eterea.core.service.hexagonal.stock.articulomovimiento.infrastructure.web.mapper.ArticuloMovimientoDtoMapper;
+import eterea.core.service.hexagonal.stock.articulomovimiento.infrastructure.web.dto.ArticuloMovimientoResponse;
 import eterea.core.service.hexagonal.tesoreria.valormovimiento.infrastructure.web.mapper.ValorMovimientoDtoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -19,6 +25,8 @@ public class PendingCountsDtoMapper {
     private final CuentaMovimientoDtoMapper cuentaMovimientoDtoMapper;
     private final ValorMovimientoDtoMapper valorMovimientoDtoMapper;
     private final StockMovimientoDtoMapper stockMovimientoDtoMapper;
+    private final ArticuloMovimientoService articuloMovimientoService;
+    private final ArticuloMovimientoDtoMapper articuloMovimientoDtoMapper;
 
     public PendingCountsResponse toResponse(PendingCounts domain) {
         if (domain == null) {
@@ -31,7 +39,16 @@ public class PendingCountsDtoMapper {
                 .countValorMovimiento(domain.getCountValorMovimiento())
                 .countStockMovimiento(domain.getCountStockMovimiento())
                 .clienteMovimientos(domain.getClienteMovimientos() != null
-                        ? domain.getClienteMovimientos().stream().map(clienteMovimientoDtoMapper::toResponse).toList()
+                        ? domain.getClienteMovimientos().stream().map(cm -> {
+                            ClienteMovimientoResponse response = clienteMovimientoDtoMapper.toResponse(cm);
+                            if (response != null) {
+                                response.setArticuloMovimientos(articuloMovimientoService.findAllByClienteMovimientoId(cm.getClienteMovimientoId())
+                                        .stream()
+                                        .map(articuloMovimientoDtoMapper::toResponse)
+                                        .toList());
+                            }
+                            return response;
+                        }).toList()
                         : Collections.emptyList())
                 .cuentaMovimientos(domain.getCuentaMovimientos() != null
                         ? domain.getCuentaMovimientos().stream().map(cuentaMovimientoDtoMapper::toResponse).toList()
@@ -40,7 +57,16 @@ public class PendingCountsDtoMapper {
                         ? domain.getValorMovimientos().stream().map(valorMovimientoDtoMapper::toResponse).toList()
                         : Collections.emptyList())
                 .stockMovimientos(domain.getStockMovimientos() != null
-                        ? domain.getStockMovimientos().stream().map(stockMovimientoDtoMapper::toResponse).toList()
+                        ? domain.getStockMovimientos().stream().map(sm -> {
+                            StockMovimientoResponse response = stockMovimientoDtoMapper.toResponse(sm);
+                            if (response != null) {
+                                response.setArticuloMovimientos(articuloMovimientoService.findAllByStockMovimientoId(sm.getStockMovimientoId())
+                                        .stream()
+                                        .map(articuloMovimientoDtoMapper::toResponse)
+                                        .toList());
+                            }
+                            return response;
+                        }).toList()
                         : Collections.emptyList())
                 .build();
     }

--- a/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/domain/model/ArticuloMovimiento.java
+++ b/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/domain/model/ArticuloMovimiento.java
@@ -2,6 +2,7 @@ package eterea.core.service.hexagonal.stock.articulomovimiento.domain.model;
 
 import eterea.core.service.hexagonal.stock.articulo.domain.model.Articulo;
 import eterea.core.service.tool.Jsonifier;
+import eterea.core.service.tool.Jsonifyable;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -12,7 +13,7 @@ import java.time.OffsetDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ArticuloMovimiento {
+public class ArticuloMovimiento implements Jsonifyable {
 
     private Long articuloMovimientoId;
     private Long clienteMovimientoId;
@@ -42,9 +43,7 @@ public class ArticuloMovimiento {
     private String trackUuid;
     private BigDecimal totalConIva;
     private BigDecimal totalSinIva;
+
     private Articulo articulo;
 
-    public String jsonify() {
-        return Jsonifier.builder(this).build();
-    }
 }

--- a/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/infrastructure/web/dto/ArticuloMovimientoResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/infrastructure/web/dto/ArticuloMovimientoResponse.java
@@ -1,5 +1,6 @@
 package eterea.core.service.hexagonal.stock.articulomovimiento.infrastructure.web.dto;
 
+import eterea.core.service.hexagonal.stock.articulo.infrastructure.web.dto.ArticuloResponse;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -14,6 +15,7 @@ public class ArticuloMovimientoResponse {
     private Long articuloMovimientoId;
     private Long clienteMovimientoId;
     private Long stockMovimientoId;
+    private Long tenenciaMovimientoId;
     private Integer centroStockId;
     private Integer comprobanteId;
     private Integer item;
@@ -23,7 +25,20 @@ public class ArticuloMovimientoResponse {
     private BigDecimal precioUnitario;
     private BigDecimal precioUnitarioSinIva;
     private BigDecimal precioUnitarioConIva;
+    private Long numeroCuenta;
+    private Byte iva105;
+    private Byte exento;
     private OffsetDateTime fechaMovimiento;
+    private OffsetDateTime fechaFactura;
+    private Integer nivel;
+    private Long cierreCajaId;
+    private Long cierreRestaurantId;
+    private BigDecimal precioCompra;
+    private BigDecimal precioValuacion;
+    private Long mozoId;
+    private BigDecimal comision;
+    private String trackUuid;
     private BigDecimal totalConIva;
     private BigDecimal totalSinIva;
+    private ArticuloResponse articulo;
 }

--- a/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/infrastructure/web/mapper/ArticuloMovimientoDtoMapper.java
+++ b/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/infrastructure/web/mapper/ArticuloMovimientoDtoMapper.java
@@ -1,11 +1,16 @@
 package eterea.core.service.hexagonal.stock.articulomovimiento.infrastructure.web.mapper;
 
+import eterea.core.service.hexagonal.stock.articulo.infrastructure.web.mapper.ArticuloDtoMapper;
 import eterea.core.service.hexagonal.stock.articulomovimiento.domain.model.ArticuloMovimiento;
 import eterea.core.service.hexagonal.stock.articulomovimiento.infrastructure.web.dto.ArticuloMovimientoResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ArticuloMovimientoDtoMapper {
+
+    private final ArticuloDtoMapper articuloDtoMapper;
 
     public ArticuloMovimientoResponse toResponse(ArticuloMovimiento domain) {
         if (domain == null) return null;
@@ -13,6 +18,7 @@ public class ArticuloMovimientoDtoMapper {
                 .articuloMovimientoId(domain.getArticuloMovimientoId())
                 .clienteMovimientoId(domain.getClienteMovimientoId())
                 .stockMovimientoId(domain.getStockMovimientoId())
+                .tenenciaMovimientoId(domain.getTenenciaMovimientoId())
                 .centroStockId(domain.getCentroStockId())
                 .comprobanteId(domain.getComprobanteId())
                 .item(domain.getItem())
@@ -22,9 +28,22 @@ public class ArticuloMovimientoDtoMapper {
                 .precioUnitario(domain.getPrecioUnitario())
                 .precioUnitarioSinIva(domain.getPrecioUnitarioSinIva())
                 .precioUnitarioConIva(domain.getPrecioUnitarioConIva())
+                .numeroCuenta(domain.getNumeroCuenta())
+                .iva105(domain.getIva105())
+                .exento(domain.getExento())
                 .fechaMovimiento(domain.getFechaMovimiento())
+                .fechaFactura(domain.getFechaFactura())
+                .nivel(domain.getNivel())
+                .cierreCajaId(domain.getCierreCajaId())
+                .cierreRestaurantId(domain.getCierreRestaurantId())
+                .precioCompra(domain.getPrecioCompra())
+                .precioValuacion(domain.getPrecioValuacion())
+                .mozoId(domain.getMozoId())
+                .comision(domain.getComision())
+                .trackUuid(domain.getTrackUuid())
                 .totalConIva(domain.getTotalConIva())
                 .totalSinIva(domain.getTotalSinIva())
+                .articulo(articuloDtoMapper.toResponse(domain.getArticulo()))
                 .build();
     }
 }

--- a/src/main/java/eterea/core/service/hexagonal/stock/stockmovimiento/infrastructure/web/dto/StockMovimientoResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/stock/stockmovimiento/infrastructure/web/dto/StockMovimientoResponse.java
@@ -2,6 +2,9 @@ package eterea.core.service.hexagonal.stock.stockmovimiento.infrastructure.web.d
 
 import lombok.*;
 
+import eterea.core.service.hexagonal.stock.articulomovimiento.infrastructure.web.dto.ArticuloMovimientoResponse;
+import java.util.List;
+
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
@@ -44,5 +47,6 @@ public class StockMovimientoResponse {
     private Byte facturaProveedor;
     private BigDecimal netoFactura;
     private BigDecimal netoRegistrado;
+    private List<ArticuloMovimientoResponse> articuloMovimientos;
 
 }

--- a/src/main/java/eterea/core/service/hexagonal/ventas/clientemovimiento/infrastructure/web/dto/ClienteMovimientoResponse.java
+++ b/src/main/java/eterea/core/service/hexagonal/ventas/clientemovimiento/infrastructure/web/dto/ClienteMovimientoResponse.java
@@ -4,6 +4,9 @@ import eterea.core.service.hexagonal.comprobante.infrastructure.web.dto.Comproba
 import eterea.core.service.hexagonal.empresa.infrastructure.web.dto.EmpresaResponse;
 import lombok.*;
 
+import eterea.core.service.hexagonal.stock.articulomovimiento.infrastructure.web.dto.ArticuloMovimientoResponse;
+import java.util.List;
+
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
@@ -61,4 +64,5 @@ public class ClienteMovimientoResponse {
     private ClienteResponse cliente;
     private MonedaResponse moneda;
     private EmpresaResponse empresa;
+    private List<ArticuloMovimientoResponse> articuloMovimientos;
 }


### PR DESCRIPTION
Closes #198

## Descripción

Release v2.5.1 que amplía el DTO `ArticuloMovimientoResponse` con 14 campos nuevos y enriquece las respuestas de cierre de caja para incluir los movimientos de artículos asociados a los conteos pendientes.

## Cambios Realizados

- [ ] **feat(articulomovimiento-dto):** Ampliación de `ArticuloMovimientoResponse` con 14 campos nuevos: `tenenciaMovimientoId`, `numeroCuenta`, `iva105`, `exento`, `fechaFactura`, `nivel`, `cierreCajaId`, `cierreRestaurantId`, `precioCompra`, `precioValuacion`, `mozoId`, `comision`, `trackUuid` y `articulo`
- [ ] **feat(cierrecaja):** Enriquecimiento de `PendingCountsDtoMapper` para poblar `articuloMovimientos` en `ClienteMovimientoResponse` y `StockMovimientoResponse`
- [ ] **feat(stockmovimiento-dto):** Nuevo campo `articuloMovimientos` en `StockMovimientoResponse`
- [ ] **feat(clientemovimiento-dto):** Nuevo campo `articuloMovimientos` en `ClienteMovimientoResponse`
- [ ] **refactor(articulomovimiento):** `ArticuloMovimiento` implementa interfaz `Jsonifyable`
- [ ] **refactor(articulomovimiento-mapper):** `ArticuloMovimientoDtoMapper` migrado a `@RequiredArgsConstructor` con inyección de `ArticuloDtoMapper`
- [ ] **chore(release):** Bump de versión a 2.5.1 en `pom.xml`, `README.md` y `CHANGELOG.md`

## Verificación

- Verificar que el proyecto compila correctamente con `mvn clean compile`.
- Verificar que los endpoints de cierre de caja (`PendingCountsResponse`) devuelven los campos `articuloMovimientos` dentro de `ClienteMovimientoResponse` y `StockMovimientoResponse`.
- Verificar que la serialización JSON de `ArticuloMovimiento` funciona correctamente al implementar `Jsonifyable`.
