### PR TITLE
fix(articulomovimiento): add null-safety check for precioUnitarioSinIva to prevent ArithmeticException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.5.3] - 2026-07-14
+
+### Fixed
+- **fix(articulomovimiento)**: Null-safety en `AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl` — se verifica que `precioUnitarioSinIva` no sea null ni cero antes de calcular `tasaImpuesto`, previniendo `ArithmeticException` (división por cero) y `NullPointerException`. Si el precio unitario sin IVA es null o cero, `tasaImpuesto` se establece en `BigDecimal.ONE` (1.000)
+
 ## [2.5.2] - 2026-07-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-blue.svg)](https://springdoc.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-9.7.0-orange.svg)](https://www.mysql.com/)
 [![License](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-2.5.2-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.5.3-blue.svg)](https://github.com/ETEREA-services/ETEREA.core-service/releases)
 
 ## Descripción
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.termascacheuta</groupId>
     <artifactId>eterea.core.service</artifactId>
-    <version>2.5.2</version>
+    <version>2.5.3</version>
     <name>ETEREA.core-service</name>
     <description>API - Eterea - Core</description>
     <properties>

--- a/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/application/usecases/AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl.java
+++ b/src/main/java/eterea/core/service/hexagonal/stock/articulomovimiento/application/usecases/AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl.java
@@ -25,7 +25,14 @@ public class AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl implements Auto
         List<ArticuloMovimiento> movimientos = repository.findAllByClienteMovimientoId(clienteMovimientoId);
         log.debug("\n\nArticuloMovimientos -> {}\n\n", Jsonifier.builder(movimientos).build());
         movimientos.forEach(movimiento -> {
-            var tasaImpuesto = movimiento.getPrecioUnitarioConIva().divide(movimiento.getPrecioUnitarioSinIva(), 3, RoundingMode.HALF_UP);
+            BigDecimal tasaImpuesto;
+            if (movimiento.getPrecioUnitarioSinIva() != null
+                    && movimiento.getPrecioUnitarioSinIva().compareTo(BigDecimal.ZERO) != 0) {
+                tasaImpuesto = movimiento.getPrecioUnitarioConIva().divide(
+                        movimiento.getPrecioUnitarioSinIva(), 3, RoundingMode.HALF_UP);
+            } else {
+                tasaImpuesto = BigDecimal.ONE;
+            }
             if (movimiento.getTotalConIva().compareTo(BigDecimal.ZERO) == 0) {
                 movimiento.setTotalConIva(movimiento.getPrecioUnitarioConIva().multiply(movimiento.getCantidad().abs()));
             }


### PR DESCRIPTION
## Descripción

Se agrega verificación null-safety para `precioUnitarioSinIva` en el cálculo de `tasaImpuesto` dentro de `AutoCompleteTotalesByClienteMovimientoIdUseCaseImpl`, previniendo `ArithmeticException` (división por cero) y `NullPointerException`.

## Cambios Realizados

- **fix(articulomovimiento):** Se valida que `precioUnitarioSinIva` no sea null ni cero antes de realizar la división; en caso contrario, `tasaImpuesto` se establece en `BigDecimal.ONE`.
- **Version bump:** `2.5.2` → `2.5.3` en `pom.xml`, `README.md` badges y `CHANGELOG.md`.

## Verificación

- La aplicación compila sin errores (`mvn compile`).
- Se cubren los casos: `precioUnitarioSinIva` = null, = 0, y > 0.
- No hay cambios en la lógica de negocio existente (funciona igual cuando el valor es válido).
